### PR TITLE
Make browser chrome white

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -183,7 +183,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         />
         <link rel="apple-touch-icon" href="/apple-icon-180.png"></link>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="theme-color" content="#000000" />
+        <meta name="theme-color" content="#FFFFFF" />
       </Head>
       <Component {...pageProps} />
     </>


### PR DESCRIPTION
Make color white to play better with browsers that let us customize the chrome UI. Makes it look nice when using Chrome's save as app feature