### PR TITLE
Bring iOS app to parity with web: track-aware search, play-from-timestamp, design polish

### DIFF
--- a/ios/Soulector.xcodeproj/project.pbxproj
+++ b/ios/Soulector.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		AA000010 /* EpisodeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000010 /* EpisodeRowView.swift */; };
 		AA000011 /* EpisodeDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000011 /* EpisodeDetailSheet.swift */; };
 		AA000012 /* MiniPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000012 /* MiniPlayerView.swift */; };
+		AA000020 /* SearchIndexEpisode.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000020 /* SearchIndexEpisode.swift */; };
+		AA000021 /* EpisodeSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000021 /* EpisodeSearch.swift */; };
+		AA000022 /* SearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000022 /* SearchResultsView.swift */; };
 		AA000014 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB000014 /* Assets.xcassets */; };
 		AA000015 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB000015 /* Preview Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -37,6 +40,9 @@
 		AB000010 /* EpisodeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeRowView.swift; sourceTree = "<group>"; };
 		AB000011 /* EpisodeDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeDetailSheet.swift; sourceTree = "<group>"; };
 		AB000012 /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
+		AB000020 /* SearchIndexEpisode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexEpisode.swift; sourceTree = "<group>"; };
+		AB000021 /* EpisodeSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeSearch.swift; sourceTree = "<group>"; };
+		AB000022 /* SearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsView.swift; sourceTree = "<group>"; };
 		AB000014 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AB000015 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AB000016 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -82,6 +88,7 @@
 			children = (
 				AB000003 /* Episode.swift */,
 				AB000004 /* EpisodeTrack.swift */,
+				AB000020 /* SearchIndexEpisode.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -107,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				AB000008 /* EpisodesViewModel.swift */,
+				AB000021 /* EpisodeSearch.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -119,6 +127,7 @@
 				AB000010 /* EpisodeRowView.swift */,
 				AB000011 /* EpisodeDetailSheet.swift */,
 				AB000012 /* MiniPlayerView.swift */,
+				AB000022 /* SearchResultsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -221,6 +230,9 @@
 				AA000010 /* EpisodeRowView.swift in Sources */,
 				AA000011 /* EpisodeDetailSheet.swift in Sources */,
 				AA000012 /* MiniPlayerView.swift in Sources */,
+				AA000020 /* SearchIndexEpisode.swift in Sources */,
+				AA000021 /* EpisodeSearch.swift in Sources */,
+				AA000022 /* SearchResultsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Soulector/Models/EpisodeTrack.swift
+++ b/ios/Soulector/Models/EpisodeTrack.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct EpisodeTrack: Identifiable, Equatable, Decodable {
+struct EpisodeTrack: Identifiable, Equatable, Codable {
     let order: Int
     let name: String
     let artist: String

--- a/ios/Soulector/Models/SearchIndexEpisode.swift
+++ b/ios/Soulector/Models/SearchIndexEpisode.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// An episode plus its track listing, as returned by `episodes.searchIndex`.
+/// The projection is a superset of `episodes.all`, so the episode fields decode
+/// straight into `Episode` and we only add the `tracks` array on top.
+struct SearchIndexEpisode: Identifiable, Codable {
+    let episode: Episode
+    let tracks: [EpisodeTrack]
+
+    var id: String { episode.id }
+
+    private enum CodingKeys: String, CodingKey {
+        case tracks
+    }
+
+    init(from decoder: Decoder) throws {
+        episode = try Episode(from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        tracks = try container.decodeIfPresent([EpisodeTrack].self, forKey: .tracks) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try episode.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(tracks, forKey: .tracks)
+    }
+}

--- a/ios/Soulector/Networking/APIClient.swift
+++ b/ios/Soulector/Networking/APIClient.swift
@@ -62,6 +62,14 @@ final class APIClient {
     static let shared = APIClient()
     private init() {}
 
+    /// Stream URLs are effectively immutable per episode, so cache them for the app session.
+    private actor StreamUrlCache {
+        private var entries: [String: StreamUrls] = [:]
+        func get(_ id: String) -> StreamUrls? { entries[id] }
+        func set(_ id: String, _ urls: StreamUrls) { entries[id] = urls }
+    }
+    private let streamUrlCache = StreamUrlCache()
+
     private let baseURL = "https://soulector.app/api/trpc"
     private let session: URLSession = {
         let config = URLSessionConfiguration.default
@@ -103,8 +111,11 @@ final class APIClient {
 
     /// Returns nil when the episode is not found.
     func fetchStreamUrl(episodeId: String) async throws -> StreamUrls? {
+        if let cached = await streamUrlCache.get(episodeId) { return cached }
         let url = try makeURL(procedure: "episode.getStreamUrl", input: ["episodeId": episodeId])
-        return try await fetch(url)
+        let urls: StreamUrls? = try await fetch(url)
+        if let urls { await streamUrlCache.set(episodeId, urls) }
+        return urls
     }
 
     func fetchAccentColor(episodeId: String) async throws -> AccentColor {

--- a/ios/Soulector/Networking/APIClient.swift
+++ b/ios/Soulector/Networking/APIClient.swift
@@ -127,4 +127,12 @@ final class APIClient {
         let url = try makeURL(procedure: "episode.getTracks", input: ["episodeId": episodeId])
         return try await fetch(url)
     }
+
+    /// Full search index: every episode across all collectives with its tracks.
+    /// The procedure takes no input, so — like the web calling it with
+    /// `undefined` — we send no `input` query param at all.
+    func fetchSearchIndex() async throws -> [SearchIndexEpisode] {
+        guard let url = URL(string: "\(baseURL)/episodes.searchIndex") else { throw APIError.badURL }
+        return try await fetch(url)
+    }
 }

--- a/ios/Soulector/Stores/PlayerStore.swift
+++ b/ios/Soulector/Stores/PlayerStore.swift
@@ -51,6 +51,7 @@ final class PlayerStore: ObservableObject {
     private var accentColorTask: Task<Void, Never>?
     private var loadedArtwork: MPMediaItemArtwork?
     private var loadedArtworkEpisodeId: String?
+    private var pendingSeek: Double?
 
     // MARK: Init
 
@@ -118,11 +119,14 @@ final class PlayerStore: ObservableObject {
     // MARK: Playback control
 
     /// Main entry point: sets loading state, fetches the stream URL, and starts playback.
-    func play(episode: Episode) async {
+    /// `startingAt` seeds an initial seek applied once the audio is ready to play; while
+    /// loading we reflect it in `currentTime` so the UI points at the target track immediately.
+    func play(episode: Episode, startingAt seconds: Double? = nil) async {
         tearDown()
 
         currentEpisode = episode
-        currentTime = 0
+        currentTime = seconds ?? 0
+        pendingSeek = seconds
         duration = 0
         currentTracks = []
         state = .loading
@@ -179,9 +183,13 @@ final class PlayerStore: ObservableObject {
                 guard let self else { return }
                 switch status {
                 case .readyToPlay:
+                    self.updateDuration()
+                    if let seek = self.pendingSeek {
+                        self.pendingSeek = nil
+                        self.seek(to: seek)
+                    }
                     self.player?.play()
                     self.state = .playing
-                    self.updateDuration()
                     self.updateNowPlayingInfo()
                 case .failed:
                     self.state = .error(item.error?.localizedDescription ?? "Playback failed")
@@ -296,6 +304,7 @@ final class PlayerStore: ObservableObject {
         accentColor = .black
         loadedArtwork = nil
         loadedArtworkEpisodeId = nil
+        pendingSeek = nil
     }
 
     // MARK: Now Playing Info

--- a/ios/Soulector/ViewModels/EpisodeSearch.swift
+++ b/ios/Soulector/ViewModels/EpisodeSearch.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// A single search result: an episode plus whichever of its tracks matched.
+struct EpisodeSearchResult: Identifiable {
+    let episode: Episode
+    /// Whether the episode title itself matched the query.
+    let episodeTitleMatch: Bool
+    /// Matching tracks within this episode, sorted by order.
+    let matchedTracks: [EpisodeTrack]
+
+    var id: String { episode.id }
+}
+
+/// Client-side search over episodes and their tracks. This ports the spirit of
+/// the web app's Fuse.js extended search: the query is split into tokens and a
+/// target matches only when it contains ALL of them (order-independent,
+/// case- and diacritic-insensitive), which mirrors the web's AND-of-terms.
+enum EpisodeSearch {
+    private static let foldingOptions: String.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
+    private static let maxResults = 100
+
+    /// Lowercase, replace non-alphanumerics with spaces, split, drop tokens < 2 chars.
+    static func tokenize(_ query: String) -> [String] {
+        let cleaned = query.folding(options: foldingOptions, locale: nil)
+            .map { $0.isLetter || $0.isNumber ? $0 : " " }
+        return String(cleaned)
+            .split(separator: " ")
+            .map(String.init)
+            .filter { $0.count >= 2 }
+    }
+
+    private static func matches(_ target: String, tokens: [String]) -> Bool {
+        let folded = target.folding(options: foldingOptions, locale: nil)
+        return tokens.allSatisfy { folded.contains($0) }
+    }
+
+    /// Groups matches by episode and ranks title matches ahead of track-only
+    /// matches, preserving the index's release-date order within each group.
+    static func search(
+        index: [SearchIndexEpisode],
+        query: String,
+        collective: CollectiveFilter
+    ) -> [EpisodeSearchResult] {
+        let tokens = tokenize(query)
+        guard !tokens.isEmpty else { return [] }
+
+        let scoped = collective == .all
+            ? index
+            : index.filter { $0.episode.collectiveSlug == collective.rawValue }
+
+        var titled: [EpisodeSearchResult] = []
+        var trackOnly: [EpisodeSearchResult] = []
+
+        for item in scoped {
+            let titleMatch = matches(item.episode.name, tokens: tokens)
+            let matchedTracks = item.tracks
+                .filter { matches("\($0.name) \($0.artist)", tokens: tokens) }
+                .sorted { $0.order < $1.order }
+
+            guard titleMatch || !matchedTracks.isEmpty else { continue }
+
+            let result = EpisodeSearchResult(
+                episode: item.episode,
+                episodeTitleMatch: titleMatch,
+                matchedTracks: matchedTracks
+            )
+            if titleMatch {
+                titled.append(result)
+            } else {
+                trackOnly.append(result)
+            }
+        }
+
+        return Array((titled + trackOnly).prefix(maxResults))
+    }
+}

--- a/ios/Soulector/ViewModels/EpisodesViewModel.swift
+++ b/ios/Soulector/ViewModels/EpisodesViewModel.swift
@@ -32,11 +32,21 @@ final class EpisodesViewModel: ObservableObject {
     @Published var selectedCollective: CollectiveFilter = .soulection
     @Published var searchText = ""
 
+    /// Full episodes+tracks index that drives track-aware search. Populated from
+    /// disk at init (instant search on launch) and refreshed from the network.
+    @Published private(set) var searchIndex: [SearchIndexEpisode] = []
+    private var isLoadingSearchIndex = false
+
     private let persistedCollectiveKey = "soulector.selectedCollective"
 
     private static let cacheURL: URL? = FileManager.default
         .urls(for: .cachesDirectory, in: .userDomainMask).first?
         .appendingPathComponent("episodes_cache.json")
+
+    // Versioned filename so a shape change never decodes a stale snapshot.
+    private static let searchIndexCacheURL: URL? = FileManager.default
+        .urls(for: .cachesDirectory, in: .userDomainMask).first?
+        .appendingPathComponent("search_index_cache_v1.json")
 
     init() {
         // Restore last-used collective
@@ -50,6 +60,11 @@ final class EpisodesViewModel: ObservableObject {
            let cached = try? JSONDecoder().decode([Episode].self, from: data) {
             episodes = cached
         }
+        if let url = Self.searchIndexCacheURL,
+           let data = try? Data(contentsOf: url),
+           let cached = try? JSONDecoder().decode([SearchIndexEpisode].self, from: data) {
+            searchIndex = cached
+        }
     }
 
     private func persistCache(_ episodes: [Episode]) {
@@ -59,8 +74,18 @@ final class EpisodesViewModel: ObservableObject {
         try? data.write(to: url, options: .atomic)
     }
 
+    private func persistSearchIndexCache(_ index: [SearchIndexEpisode]) {
+        guard let url = Self.searchIndexCacheURL,
+              let data = try? JSONEncoder().encode(index)
+        else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
     // MARK: Derived lists
 
+    /// Collective-scoped episode list (search is handled separately, see
+    /// `searchResults`). Used for the regular list, shuffle scope, and
+    /// auto-advance.
     var filteredEpisodes: [Episode] {
         applyFilters(to: episodes)
     }
@@ -70,15 +95,19 @@ final class EpisodesViewModel: ObservableObject {
     }
 
     private func applyFilters(to list: [Episode]) -> [Episode] {
-        var result = list
-        if selectedCollective != .all {
-            result = result.filter { $0.collectiveSlug == selectedCollective.rawValue }
-        }
-        if !searchText.trimmingCharacters(in: .whitespaces).isEmpty {
-            result = result.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
-        }
-        return result
+        guard selectedCollective != .all else { return list }
+        return list.filter { $0.collectiveSlug == selectedCollective.rawValue }
     }
+
+    // MARK: Track-aware search
+
+    var searchResults: [EpisodeSearchResult] {
+        EpisodeSearch.search(index: searchIndex, query: searchText, collective: selectedCollective)
+    }
+
+    /// True until the search index has been loaded (from cache or network) at
+    /// least once, used to show a "loading library" state instead of "no matches".
+    var isSearchIndexLoading: Bool { searchIndex.isEmpty }
 
     // MARK: Collective selection
 
@@ -102,5 +131,21 @@ final class EpisodesViewModel: ObservableObject {
             if episodes.isEmpty { self.error = error }
         }
         isLoading = false
+    }
+
+    /// Refreshes the search index from the network. Safe to call repeatedly; a
+    /// fetch in flight short-circuits. Failures are swallowed — cached data (if
+    /// any) keeps search working.
+    func refreshSearchIndex() async {
+        guard !isLoadingSearchIndex else { return }
+        isLoadingSearchIndex = true
+        defer { isLoadingSearchIndex = false }
+        do {
+            let fetched = try await APIClient.shared.fetchSearchIndex()
+            searchIndex = fetched
+            persistSearchIndexCache(fetched)
+        } catch {
+            // Ignore; cached index (if present) still serves search this session.
+        }
     }
 }

--- a/ios/Soulector/Views/EpisodeDetailSheet.swift
+++ b/ios/Soulector/Views/EpisodeDetailSheet.swift
@@ -105,7 +105,7 @@ struct EpisodeDetailSheet: View {
                             .tint(.white)
                             .padding()
                     } else if !tracks.isEmpty {
-                        TracklistView(tracks: tracks, episode: episode, playerStore: playerStore)
+                        TracklistView(tracks: tracks, episode: episode)
                     }
 
                     Spacer(minLength: 32)
@@ -241,7 +241,7 @@ private struct PlayerControlsSection: View {
 struct TracklistView: View {
     let tracks: [EpisodeTrack]
     let episode: Episode
-    let playerStore: PlayerStore
+    @EnvironmentObject var playerStore: PlayerStore
 
     private var currentTrack: EpisodeTrack? {
         guard playerStore.currentEpisode?.id == episode.id else { return nil }
@@ -262,7 +262,7 @@ struct TracklistView: View {
 
             ForEach(tracks) { track in
                 let isCurrent = currentTrack?.id == track.id
-                TrackRow(track: track, isCurrent: isCurrent, playerStore: playerStore)
+                TrackRow(track: track, isCurrent: isCurrent)
                 Divider().background(Color.white.opacity(0.1)).padding(.horizontal, 20)
             }
         }
@@ -291,7 +291,7 @@ private struct PingRing: View {
 private struct TrackRow: View {
     let track: EpisodeTrack
     let isCurrent: Bool
-    let playerStore: PlayerStore
+    @EnvironmentObject var playerStore: PlayerStore
 
     var body: some View {
         Button(action: {

--- a/ios/Soulector/Views/EpisodeDetailSheet.swift
+++ b/ios/Soulector/Views/EpisodeDetailSheet.swift
@@ -105,7 +105,7 @@ struct EpisodeDetailSheet: View {
                             .tint(.white)
                             .padding()
                     } else if !tracks.isEmpty {
-                        TracklistView(tracks: tracks, playerStore: playerStore)
+                        TracklistView(tracks: tracks, episode: episode, playerStore: playerStore)
                     }
 
                     Spacer(minLength: 32)
@@ -240,7 +240,17 @@ private struct PlayerControlsSection: View {
 
 struct TracklistView: View {
     let tracks: [EpisodeTrack]
+    let episode: Episode
     let playerStore: PlayerStore
+
+    private var currentTrack: EpisodeTrack? {
+        guard playerStore.currentEpisode?.id == episode.id else { return nil }
+        let t = playerStore.currentTime
+        return tracks.filter { track in
+            guard let ts = track.timestamp else { return false }
+            return t >= Double(ts)
+        }.last
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -251,15 +261,36 @@ struct TracklistView: View {
                 .padding(.bottom, 12)
 
             ForEach(tracks) { track in
-                TrackRow(track: track, playerStore: playerStore)
+                let isCurrent = currentTrack?.id == track.id
+                TrackRow(track: track, isCurrent: isCurrent, playerStore: playerStore)
                 Divider().background(Color.white.opacity(0.1)).padding(.horizontal, 20)
             }
         }
     }
 }
 
+private struct PingRing: View {
+    @State private var scale: CGFloat = 1.0
+    @State private var opacity: Double = 0.5
+
+    var body: some View {
+        Circle()
+            .stroke(Color.white, lineWidth: 1.5)
+            .frame(width: 20, height: 20)
+            .scaleEffect(scale)
+            .opacity(opacity)
+            .onAppear {
+                withAnimation(.easeOut(duration: 1.5).repeatForever(autoreverses: false)) {
+                    scale = 2.0
+                    opacity = 0
+                }
+            }
+    }
+}
+
 private struct TrackRow: View {
     let track: EpisodeTrack
+    let isCurrent: Bool
     let playerStore: PlayerStore
 
     var body: some View {
@@ -268,35 +299,54 @@ private struct TrackRow: View {
                 playerStore.seek(to: Double(ts))
             }
         }) {
-            HStack(alignment: .center, spacing: 12) {
-                // Track number or timestamp
-                if let ts = track.formattedTimestamp {
-                    Text(ts)
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundColor(.white.opacity(0.4))
-                        .frame(width: 52, alignment: .leading)
-                } else {
-                    Text("\(track.order)")
-                        .font(.system(size: 12))
-                        .foregroundColor(.white.opacity(0.4))
-                        .frame(width: 24, alignment: .center)
-                }
+            ZStack(alignment: .leading) {
+                // Left current-track bar
+                Rectangle()
+                    .fill(Color.white)
+                    .frame(width: 2)
+                    .opacity(isCurrent ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.3), value: isCurrent)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(track.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white)
-                        .lineLimit(1)
-                    Text(track.artist)
-                        .font(.system(size: 12))
-                        .foregroundColor(.white.opacity(0.55))
-                        .lineLimit(1)
-                }
+                HStack(alignment: .center, spacing: 12) {
+                    // Track number / timestamp with current indicator
+                    ZStack {
+                        if isCurrent {
+                            PingRing()
+                            Circle()
+                                .fill(Color.white)
+                                .frame(width: 20, height: 20)
+                            Text("\(track.order)")
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundColor(.black)
+                        } else if let ts = track.formattedTimestamp {
+                            Text(ts)
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundColor(.white.opacity(0.4))
+                        } else {
+                            Text("\(track.order)")
+                                .font(.system(size: 12))
+                                .foregroundColor(.white.opacity(0.4))
+                        }
+                    }
+                    .frame(width: 52, alignment: .leading)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(track.name)
+                            .font(.system(size: 13, weight: isCurrent ? .bold : .medium))
+                            .foregroundColor(.white)
+                            .lineLimit(1)
+                        Text(track.artist)
+                            .font(.system(size: 12))
+                            .foregroundColor(.white.opacity(isCurrent ? 1.0 : 0.55))
+                            .lineLimit(1)
+                    }
+                    .animation(.easeInOut(duration: 0.3), value: isCurrent)
+
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
         }
         .buttonStyle(.plain)
         .disabled(track.timestamp == nil)

--- a/ios/Soulector/Views/EpisodeDetailSheet.swift
+++ b/ios/Soulector/Views/EpisodeDetailSheet.swift
@@ -180,9 +180,9 @@ private struct PlayerControlsSection: View {
                 if isCurrentEpisode {
                     Button(action: {
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        playerStore.rewind()
+                        playerStore.rewind(30)
                     }) {
-                        Image(systemName: "gobackward.15")
+                        Image(systemName: "gobackward.30")
                             .font(.system(size: 26))
                             .foregroundColor(.white)
                     }
@@ -217,9 +217,9 @@ private struct PlayerControlsSection: View {
                 if isCurrentEpisode {
                     Button(action: {
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        playerStore.forward()
+                        playerStore.forward(30)
                     }) {
-                        Image(systemName: "goforward.15")
+                        Image(systemName: "goforward.30")
                             .font(.system(size: 26))
                             .foregroundColor(.white)
                     }
@@ -262,7 +262,7 @@ struct TracklistView: View {
 
             ForEach(tracks) { track in
                 let isCurrent = currentTrack?.id == track.id
-                TrackRow(track: track, isCurrent: isCurrent)
+                TrackRow(track: track, episode: episode, isCurrent: isCurrent)
                 Divider().background(Color.white.opacity(0.1)).padding(.horizontal, 20)
             }
         }
@@ -290,13 +290,17 @@ private struct PingRing: View {
 
 private struct TrackRow: View {
     let track: EpisodeTrack
+    let episode: Episode
     let isCurrent: Bool
     @EnvironmentObject var playerStore: PlayerStore
 
     var body: some View {
         Button(action: {
-            if let ts = track.timestamp {
+            guard let ts = track.timestamp else { return }
+            if playerStore.currentEpisode?.id == episode.id {
                 playerStore.seek(to: Double(ts))
+            } else {
+                Task { await playerStore.play(episode: episode, startingAt: Double(ts)) }
             }
         }) {
             ZStack(alignment: .leading) {

--- a/ios/Soulector/Views/EpisodeDetailSheet.swift
+++ b/ios/Soulector/Views/EpisodeDetailSheet.swift
@@ -254,7 +254,7 @@ struct TracklistView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Tracklist")
+            Text("\(tracks.count) Tracks")
                 .font(.headline)
                 .foregroundColor(.white.opacity(0.7))
                 .padding(.horizontal, 20)

--- a/ios/Soulector/Views/EpisodeRowView.swift
+++ b/ios/Soulector/Views/EpisodeRowView.swift
@@ -91,17 +91,72 @@ struct EpisodeRowView: View {
     private var playingOverlay: some View {
         ZStack {
             Color.black.opacity(0.4)
-            if #available(iOS 17.0, *) {
-                Image(systemName: "waveform")
-                    .font(.system(size: 20, weight: .medium))
-                    .foregroundColor(.white)
-                    .symbolEffect(.variableColor.iterative, options: .repeating)
-            } else {
-                Image(systemName: "waveform")
-                    .font(.system(size: 20, weight: .medium))
-                    .foregroundColor(.white)
-            }
+            EqualizerBars()
         }
         .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+// MARK: - Playing indicator (equalizer bars)
+
+/// Mirrors the web PlayingAnimation (src/client/components/Episode.tsx): three
+/// bottom-anchored bars that oscillate while playing and freeze low when paused.
+private struct EqualizerBars: View {
+    @EnvironmentObject var playerStore: PlayerStore
+
+    // Slightly different durations/phases per bar, matching the web timings.
+    private let bars: [(duration: Double, delay: Double)] = [
+        (0.50, 0.0),
+        (0.42, 0.07),
+        (0.58, 0.20),
+    ]
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 3) {
+            ForEach(bars.indices, id: \.self) { i in
+                EqualizerBar(
+                    duration: bars[i].duration,
+                    delay: bars[i].delay,
+                    isPlaying: playerStore.isPlaying
+                )
+            }
+        }
+        .frame(height: 20)
+    }
+}
+
+private struct EqualizerBar: View {
+    let duration: Double
+    let delay: Double
+    let isPlaying: Bool
+
+    private let minScale: CGFloat = 1.0 / 6.0
+    @State private var scale: CGFloat = 1.0 / 6.0
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 1)
+            .fill(Color.white)
+            .frame(width: 3, height: 20)
+            .scaleEffect(y: scale, anchor: .bottom)
+            .onAppear { apply(playing: isPlaying) }
+            .onChange(of: isPlaying) { apply(playing: $0) }
+    }
+
+    private func apply(playing: Bool) {
+        if playing {
+            scale = 1.0
+            withAnimation(
+                .easeInOut(duration: duration)
+                    .repeatForever(autoreverses: true)
+                    .delay(delay)
+            ) {
+                scale = minScale
+            }
+        } else {
+            // Finite animation cancels the repeating one and settles low.
+            withAnimation(.easeInOut(duration: 0.2)) {
+                scale = minScale
+            }
+        }
     }
 }

--- a/ios/Soulector/Views/EpisodesView.swift
+++ b/ios/Soulector/Views/EpisodesView.swift
@@ -22,6 +22,10 @@ struct EpisodesView: View {
             : episodesVM.favoriteEpisodes(favoritesStore: favoritesStore)
     }
 
+    private var isSearching: Bool {
+        !episodesVM.searchText.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             Color.black.ignoresSafeArea()
@@ -116,7 +120,14 @@ struct EpisodesView: View {
                 }
 
                 // Search toggle
-                Button(action: { withAnimation(.easeInOut(duration: 0.2)) { showSearch.toggle() } }) {
+                Button(action: {
+                    withAnimation(.easeInOut(duration: 0.2)) { showSearch.toggle() }
+                    if showSearch {
+                        Task { await episodesVM.refreshSearchIndex() }
+                    } else {
+                        episodesVM.searchText = ""
+                    }
+                }) {
                     Image(systemName: showSearch ? "xmark" : "magnifyingglass")
                         .font(.system(size: 18))
                         .foregroundColor(.white)
@@ -138,7 +149,7 @@ struct EpisodesView: View {
             Image(systemName: "magnifyingglass")
                 .foregroundColor(.white.opacity(0.5))
 
-            TextField("Search episodes...", text: $episodesVM.searchText)
+            TextField("Search episodes and tracks...", text: $episodesVM.searchText)
                 .foregroundColor(.white)
                 .tint(.white)
                 .autocorrectionDisabled()
@@ -175,12 +186,24 @@ struct EpisodesView: View {
 
             Spacer()
 
-            Text("\(displayedEpisodes.count) Total")
+            Text(countText)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(.white.opacity(0.4))
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
+    }
+
+    private var countText: String {
+        guard isSearching else { return "\(displayedEpisodes.count) Total" }
+        let results = episodesVM.searchResults
+        let episodeWord = results.count == 1 ? "episode" : "episodes"
+        var text = "\(results.count) \(episodeWord)"
+        let trackCount = results.reduce(0) { $0 + $1.matchedTracks.count }
+        if trackCount > 0 {
+            text += " · \(trackCount) \(trackCount == 1 ? "track" : "tracks")"
+        }
+        return text
     }
 
     private var collectiveDropdown: some View {
@@ -268,7 +291,24 @@ struct EpisodesView: View {
 
     @ViewBuilder
     private var episodeListContent: some View {
-        if episodesVM.isLoading && episodesVM.episodes.isEmpty {
+        if isSearching {
+            SearchResultsView(
+                results: episodesVM.searchResults,
+                loading: episodesVM.isSearchIndexLoading,
+                currentEpisodeId: playerStore.currentEpisode?.id,
+                bottomPadding: playerStore.hasEpisode ? 70 : 0,
+                isFavorite: { favoritesStore.isFavorite($0) },
+                onEpisodeTap: { episode in
+                    selectedEpisode = episode
+                    Task { await playerStore.play(episode: episode) }
+                },
+                onTrackTap: { episode, timestamp in
+                    selectedEpisode = episode
+                    Task { await playerStore.play(episode: episode, startingAt: timestamp.map(Double.init)) }
+                },
+                onFavorite: { favoritesStore.toggleFavorite($0.id) }
+            )
+        } else if episodesVM.isLoading && episodesVM.episodes.isEmpty {
             VStack {
                 Spacer()
                 ProgressView("Loading episodes…")

--- a/ios/Soulector/Views/MiniPlayerView.swift
+++ b/ios/Soulector/Views/MiniPlayerView.swift
@@ -26,17 +26,13 @@ struct MiniPlayerView: View {
 
                 // Episode name + date
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(episode.name)
-                        .font(.system(size: 14, weight: .semibold))
+                    MarqueeText(text: episode.name)
                         .foregroundColor(.white)
-                        .lineLimit(1)
                     Text(episode.formattedDate)
                         .font(.system(size: 12))
                         .foregroundColor(.white.opacity(0.5))
                         .lineLimit(1)
                 }
-
-                Spacer()
 
                 // Loading indicator or controls
                 if playerStore.isLoading {
@@ -91,5 +87,86 @@ struct MiniPlayerView: View {
                     }
                 }
         )
+    }
+}
+
+// MARK: - Marquee text
+
+/// Auto-scrolls the text when it overflows the available width, mirroring the
+/// web MarqueeText (src/client/EpisodesScreen/Player/MiniPlayerControls.tsx):
+/// two copies separated by `gap` scroll left at `speed` pt/s and loop
+/// seamlessly. Falls back to plain truncated text when it fits.
+private struct MarqueeText: View {
+    let text: String
+    var font: Font = .system(size: 14, weight: .semibold)
+    var gap: CGFloat = 40
+    var speed: CGFloat = 30 // points per second
+
+    @State private var textWidth: CGFloat = 0
+    @State private var containerWidth: CGFloat = 0
+    @State private var offset: CGFloat = 0
+
+    private var shouldMarquee: Bool { containerWidth > 0 && textWidth > containerWidth }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .clipped()
+            .background(
+                // Measure the available container width.
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear { containerWidth = proxy.size.width }
+                        .onChange(of: proxy.size.width) { containerWidth = $0 }
+                }
+            )
+            .overlay(
+                // Off-layout copy that reports the text's natural width.
+                Text(text)
+                    .font(font)
+                    .fixedSize()
+                    .background(
+                        GeometryReader { proxy in
+                            Color.clear
+                                .onAppear { textWidth = proxy.size.width }
+                                .onChange(of: proxy.size.width) { textWidth = $0 }
+                        }
+                    )
+                    .hidden()
+                    .frame(width: 0, height: 0),
+                alignment: .leading
+            )
+            .onChange(of: text) { _ in restart() }
+            .onChange(of: textWidth) { _ in restart() }
+            .onChange(of: containerWidth) { _ in restart() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if shouldMarquee {
+            HStack(spacing: gap) {
+                Text(text).font(font).fixedSize()
+                Text(text).font(font).fixedSize()
+            }
+            .offset(x: offset)
+        } else {
+            Text(text)
+                .font(font)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+    }
+
+    private func restart() {
+        // Cancel any running loop and reset before (re)starting.
+        var noAnim = Transaction()
+        noAnim.disablesAnimations = true
+        withTransaction(noAnim) { offset = 0 }
+
+        guard shouldMarquee, textWidth > 0 else { return }
+        let distance = textWidth + gap
+        withAnimation(.linear(duration: Double(distance / speed)).repeatForever(autoreverses: false)) {
+            offset = -distance
+        }
     }
 }

--- a/ios/Soulector/Views/SearchResultsView.swift
+++ b/ios/Soulector/Views/SearchResultsView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// Track-aware search results: each episode row (reusing `EpisodeRowView`)
+/// followed by its matching tracks in an indented block connected by a vertical
+/// line, mirroring the web app's SearchResults.
+struct SearchResultsView: View {
+    let results: [EpisodeSearchResult]
+    /// True while the index is still loading and there is nothing to show yet.
+    let loading: Bool
+    let currentEpisodeId: String?
+    let bottomPadding: CGFloat
+    let isFavorite: (String) -> Bool
+    let onEpisodeTap: (Episode) -> Void
+    let onTrackTap: (Episode, Int?) -> Void
+    let onFavorite: (Episode) -> Void
+
+    var body: some View {
+        if results.isEmpty {
+            emptyState
+        } else {
+            List {
+                ForEach(results) { result in
+                    VStack(alignment: .leading, spacing: 0) {
+                        EpisodeRowView(
+                            episode: result.episode,
+                            isPlaying: currentEpisodeId == result.episode.id,
+                            isFavorite: isFavorite(result.episode.id),
+                            onTap: { onEpisodeTap(result.episode) },
+                            onFavorite: { onFavorite(result.episode) }
+                        )
+                        if !result.matchedTracks.isEmpty {
+                            matchedTracks(for: result)
+                        }
+                    }
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                }
+                Color.clear
+                    .frame(height: bottomPadding)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets())
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+        }
+    }
+
+    // The connector sits under the center of the 56pt artwork (16pt row inset +
+    // 28pt) so it reads as descending from the episode.
+    private func matchedTracks(for result: EpisodeSearchResult) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            Rectangle()
+                .fill(Color.white.opacity(0.2))
+                .frame(width: 2)
+                .padding(.leading, 44)
+
+            VStack(spacing: 0) {
+                ForEach(result.matchedTracks) { track in
+                    Button(action: { onTrackTap(result.episode, track.timestamp) }) {
+                        HStack(spacing: 8) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(track.name)
+                                    .font(.system(size: 14, weight: .semibold))
+                                    .foregroundColor(.white)
+                                    .lineLimit(1)
+                                Text(track.artist)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.white.opacity(0.5))
+                                    .lineLimit(1)
+                            }
+                            Spacer(minLength: 0)
+                            if let ts = track.formattedTimestamp {
+                                Text(ts)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(.white.opacity(0.7))
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .background(Color.white.opacity(0.1))
+                                    .clipShape(Capsule())
+                            }
+                        }
+                        .padding(.vertical, 8)
+                        .padding(.leading, 14)
+                        .padding(.trailing, 16)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.bottom, 4)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            if loading {
+                Text("Loading library…")
+                    .font(.system(size: 14))
+                    .foregroundColor(.white.opacity(0.5))
+            } else {
+                Image(systemName: "music.note")
+                    .font(.system(size: 32))
+                    .foregroundColor(.white.opacity(0.3))
+                    .padding(.bottom, 4)
+                Text("No matches found")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.white)
+                Text("Try a different track, artist, or episode name.")
+                    .font(.system(size: 13))
+                    .foregroundColor(.white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 32)
+    }
+}


### PR DESCRIPTION
## Summary

Audit of the iOS app against the current web app, then implementation of every missing feature and design disparity found (plus the current-track indicator work already on this branch).

### Current track indicator (earlier commits)
- Episode detail tracklist highlights the currently playing track (left bar, ping ring, bold styling), matching the web's tracklist indicator.

### Play from a track timestamp
- `PlayerStore.play(episode:startingAt:)` applies an initial seek once the stream is ready; `currentTime` is seeded while loading so the tracklist highlight targets the right track immediately.
- Fixes a real bug: tapping a track in a *browsed* (non-playing) episode's sheet used to scrub the episode that was actually playing.
- Detail-sheet skip buttons are now 30s (web parity); lock-screen intervals stay 15s.
- Stream URLs are cached per session (web caches with `staleTime: Infinity`).

### Track-aware search (ports the web's flagship search)
- Fetches `episodes.searchIndex` with a versioned disk cache: instant, offline-capable search on launch.
- All-token, case- and diacritic-insensitive matching over episode titles and track name+artist; title matches ranked first; capped at 100; scoped to the selected collective.
- Results grouped by episode with matched tracks nested under a connector line and timestamp pills; tapping a track opens the sheet and plays that episode from the timestamp.
- Header shows "N episodes · M tracks" while searching; empty states match web copy; shuffle now ignores the search filter like the web.

### Design parity polish
- Tracklist header shows the track count ("12 Tracks").
- Mini-player title marquees when it overflows (40pt gap, 30pt/s, seamless loop), like the web mini player.
- Playing indicator is the web's equalizer bars: oscillate while playing, settle low when paused.

Intentionally not ported (iOS-idiomatic equivalents exist): options bottom sheet (long-press context menu), volume/mute slider, web's accent tinting of a light UI.

## Test plan
- [x] Builds clean for iOS 16+ (iPhone 16 Pro simulator)
- [x] Search matching logic compiled standalone and verified against the live production index (1,046 episodes / 20,623 tracks): multi-word cross-field queries, diacritic folding both directions, collective scoping, ranking, result cap
- [x] Live `episodes.searchIndex` JSON verified to decode into the new models
- [x] App installed and launched in simulator; episode list, tabs, counts render correctly
- [ ] Manual pass on device: search → tap matched track plays from timestamp; marquee on long titles; equalizer pause/resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)