### PR TITLE
Fix stale audio and seek races when switching episodes

### DIFF
--- a/src/client/EpisodesScreen/EpisodesScreen.tsx
+++ b/src/client/EpisodesScreen/EpisodesScreen.tsx
@@ -258,6 +258,9 @@ export function EpisodesScreen({ searchText }: Props) {
           {currentEpisodeId && <Player currentEpisodeId={currentEpisodeId} />}
           {USE_NEW_PLAYER && currentEpisodeId && currentEpisodeStreamUrls && (
             <EpisodeAudioPlayer
+              // Remount the <audio> element per episode so events from the
+              // previous episode's element can't leak into the new one.
+              key={currentEpisodeId}
               currentEpisodeId={currentEpisodeId}
               currentEpisodeStreamUrls={currentEpisodeStreamUrls}
             />

--- a/src/client/EpisodesScreen/PlayerStore.tsx
+++ b/src/client/EpisodesScreen/PlayerStore.tsx
@@ -43,7 +43,7 @@ export type PlayerStore = {
     loadEpisode: (episodeId: string, seekMillis?: number) => void;
     applyInitialSeek: () => void;
     setLoadingStatus: (status: PlayerLoadingStatus) => void;
-    setCurrentEpisodeStreamUrls: (urls: StreamUrls) => void;
+    setCurrentEpisodeStreamUrls: (episodeId: string, urls: StreamUrls) => void;
   };
 };
 
@@ -59,32 +59,50 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   currentEpisodeStreamUrls: null,
   initialSeekMillis: null,
   actions: {
-    setCurrentEpisodeStreamUrls(urls: StreamUrls) {
+    setCurrentEpisodeStreamUrls(episodeId: string, urls: StreamUrls) {
+      // Stream urls resolve asynchronously; if the user has since switched to
+      // a different episode this response is stale and must not be played.
+      if (get().currentEpisodeId !== episodeId) {
+        return;
+      }
       set({
         currentEpisodeStreamUrls: urls,
       });
     },
     loadEpisode(episodeId: string, seekMillis?: number) {
-      const hasEpisodeLoaded = get().currentEpisodeId !== undefined;
-      const isPlaying = get().playing;
+      const { currentEpisodeId, currentEpisodeStreamUrls } = get();
       const initialSeekMillis = seekMillis ?? null;
-      if (!hasEpisodeLoaded || !isPlaying) {
-        set({
-          // We can play the new episode since we were already playing audio
-          currentEpisodeId: episodeId,
-          progress: 0,
-          cuePosition: 0,
-          initialSeekMillis,
-        });
-      } else {
-        set({
-          playing: true,
-          currentEpisodeId: episodeId,
-          progress: 0,
-          cuePosition: 0,
-          initialSeekMillis,
-        });
+
+      // The episode is already loaded (e.g. clicking a track of the episode
+      // that's playing): just seek, no need to reload the audio.
+      if (episodeId === currentEpisodeId && currentEpisodeStreamUrls) {
+        if (initialSeekMillis !== null) {
+          set({
+            playing: true,
+            initialSeekMillis: null,
+            cuePosition: initialSeekMillis,
+            progress: initialSeekMillis,
+          });
+        } else {
+          set({ playing: true, initialSeekMillis: null });
+        }
+        return;
       }
+
+      set({
+        playing: true,
+        currentEpisodeId: episodeId,
+        // Clearing the stream urls unmounts the old <audio> element right
+        // away, so the previous episode goes silent immediately instead of
+        // playing on (and reacting to the resets below) while the new
+        // episode's audio loads.
+        currentEpisodeStreamUrls: null,
+        loadingStatus: "loading",
+        progress: initialSeekMillis ?? 0,
+        cuePosition: 0,
+        episodeDuration: 0,
+        initialSeekMillis,
+      });
     },
     applyInitialSeek() {
       const { initialSeekMillis } = get();

--- a/src/client/EpisodesScreen/useEpisodesScreenState.tsx
+++ b/src/client/EpisodesScreen/useEpisodesScreenState.tsx
@@ -38,7 +38,7 @@ export function useEpisodesScreenState() {
       mutate(episodeId, {
         onSuccess(data) {
           if (data) {
-            playerActions.setCurrentEpisodeStreamUrls(data);
+            playerActions.setCurrentEpisodeStreamUrls(episodeId, data);
           }
         },
       });
@@ -62,7 +62,7 @@ export function useEpisodesScreenState() {
       mutate(episodeId, {
         onSuccess(data) {
           if (data) {
-            playerActions.setCurrentEpisodeStreamUrls(data);
+            playerActions.setCurrentEpisodeStreamUrls(episodeId, data);
           }
         },
       });
@@ -81,12 +81,13 @@ export function useEpisodesScreenState() {
 
     let episode = sample(eps);
     if (episode) {
-      playerActions.loadEpisode(episode.id);
+      const episodeId = episode.id;
+      playerActions.loadEpisode(episodeId);
       episodeModalSheetActions.open();
-      mutate(episode.id, {
+      mutate(episodeId, {
         onSuccess(data) {
           if (data) {
-            playerActions.setCurrentEpisodeStreamUrls(data);
+            playerActions.setCurrentEpisodeStreamUrls(episodeId, data);
           }
         },
       });

--- a/src/client/components/AudioPlayer.tsx
+++ b/src/client/components/AudioPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 
 export interface AudioPlayerProps {
   mp3StreamUrl: string | null;
@@ -22,47 +22,50 @@ export function AudioPlayer({
   cuePosition,
 }: AudioPlayerProps) {
   const ref = useRef<HTMLAudioElement>(null);
-  const [shouldPlay, setShouldPlay] = useState(false);
 
-  async function onCanPlayThrough() {
+  // Duration is known as soon as metadata arrives, well before enough audio
+  // has buffered to fire canplaythrough. Reporting ready here lets the UI
+  // (and any initial track seek) settle while the audio is still buffering.
+  function onLoadedMetadata() {
     const durationSecs = ref.current?.duration ?? 0;
-    const durationMillis = durationSecs * 1000;
-
-    onReady(durationMillis);
-
-    if (shouldPlay) {
-      ref.current
-        ?.play()
-        .then(() => setShouldPlay(false))
-        .catch((err) => console.error(`onCanPlay ${err}`));
-    }
+    onReady(durationSecs * 1000);
   }
 
   useEffect(() => {
-    if (ref.current && mp3StreamUrl) {
-      ref.current.src = mp3StreamUrl;
-      ref.current.load();
-      setShouldPlay(true);
+    const audio = ref.current;
+    if (!audio || !mp3StreamUrl) {
+      return;
     }
 
+    audio.preload = "auto";
+    audio.src = mp3StreamUrl;
+    audio.load();
+    // play() waits for enough data on its own, so playback starts the moment
+    // the browser can, instead of waiting for the canplaythrough estimate.
+    audio.play().catch((err) => console.error(`audio play failed: ${err}`));
+
     return () => {
-      ref.current?.pause();
+      audio.pause();
     };
   }, [mp3StreamUrl]);
 
   useEffect(() => {
-    if (ref.current) {
+    const audio = ref.current;
+    // Never seek an element without a source: it would throw away the seek
+    // and, worse, a stale cuePosition must not touch a tearing-down player.
+    if (audio && audio.currentSrc) {
       const cuePosMillis = cuePosition ?? 0;
-      ref.current.currentTime = cuePosMillis / 1000;
+      audio.currentTime = cuePosMillis / 1000;
     }
   }, [cuePosition]);
 
   useEffect(() => {
-    if (ref.current) {
+    const audio = ref.current;
+    if (audio && audio.currentSrc) {
       if (playing) {
-        ref.current.play();
+        audio.play().catch((err) => console.error(`audio play failed: ${err}`));
       } else {
-        ref.current.pause();
+        audio.pause();
       }
     }
   }, [playing]);
@@ -74,23 +77,18 @@ export function AudioPlayer({
   }, [volume]);
 
   return (
-    <>
-      <audio
-        className="block h-px scale-y-0"
-        ref={ref}
-        onPlay={onPlay}
-        onTimeUpdate={() => {
-          if (ref.current) {
-            const currentTime = ref.current.currentTime;
-            onPlayProgressChange(currentTime * 1000);
-          }
-        }}
-        onPause={onPause}
-        // controls
-        onCanPlayThrough={onCanPlayThrough}
-        // src={mp3StreamUrl}
-        // autoPlay
-      ></audio>
-    </>
+    <audio
+      className="block h-px scale-y-0"
+      ref={ref}
+      onPlay={onPlay}
+      onPause={onPause}
+      onLoadedMetadata={onLoadedMetadata}
+      onTimeUpdate={() => {
+        if (ref.current) {
+          const currentTime = ref.current.currentTime;
+          onPlayProgressChange(currentTime * 1000);
+        }
+      }}
+    ></audio>
   );
 }


### PR DESCRIPTION
Switching episodes (or jumping to a track from search) while audio was
playing had several state races:

- The old episode kept playing for a couple seconds because the stream
  urls in the player store still pointed at it until the new ones were
  fetched. loadEpisode now clears the stream urls, which unmounts the
  old <audio> element immediately, so the old episode goes silent the
  moment a new one is selected.
- Resetting cuePosition (and later applying the initial track seek)
  could seek the *old* audio element to the new position while the new
  episode loaded. The audio element is now keyed by episode id so each
  episode gets a fresh element, seeks are ignored when no source is
  loaded, and the loading/duration/progress state is reset up front.
- Stream url responses are now tagged with their episode id and dropped
  if the user has already switched to a different episode, so a slow
  response can't start playing the wrong audio.
- Clicking a track of the episode that's already playing now seeks
  directly instead of relying on a reload that never happened.

Playback also starts faster: the player now calls play() as soon as the
source is set instead of waiting for canplaythrough, and reports
ready/duration at loadedmetadata so the UI and initial track seek
settle while the audio is still buffering.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018NgJYVfpLbe5crA67Byb1m