### PR TITLE
feat(search): shareable search URLs via AIP-160-style ?filter= param

### DIFF
--- a/src/client/EpisodesScreen/searchFilter.ts
+++ b/src/client/EpisodesScreen/searchFilter.ts
@@ -1,0 +1,95 @@
+import { EpisodeCollectiveSlugProjection } from "@/server/router";
+
+/**
+ * Shareable search state, encoded in the URL as a single `?filter=` expression.
+ *
+ * The expression follows a pragmatic subset of Google AIP-160
+ * (https://google.aip.dev/160): a sequence of restrictions implicitly ANDed
+ * together by whitespace. Today we understand exactly what the UI can produce:
+ *
+ *   - a single `collective = <slug>` restriction (the collective selector), and
+ *   - free-text terms (the search box).
+ *
+ * e.g. `collective = soulection missing you` scopes to Soulection and fuzzy
+ * searches "missing you". Baking the collective into the link means a shared URL
+ * reproduces the exact results the sharer saw, regardless of the recipient's own
+ * saved collective.
+ *
+ * The shape is intentionally small but leaves room to grow into richer AIP-160
+ * restrictions later (`track:"..."`, `name:"..."`, `-negation`, date
+ * comparisons) without changing the URL contract.
+ */
+export type SearchFilter = {
+  /** Free-text query, matched fuzzily against episode/track names. */
+  text: string;
+  /**
+   * Collective scope. `null` means the filter did not specify one, so the
+   * caller should fall back to its existing (persisted) selection.
+   */
+  collective: SearchFilterCollective | null;
+};
+
+export type SearchFilterCollective = "all" | EpisodeCollectiveSlugProjection;
+
+const COLLECTIVE_VALUES: SearchFilterCollective[] = [
+  "all",
+  "soulection",
+  "sasha-marie-radio",
+  "the-love-below-hour",
+  "local",
+];
+
+function isCollective(value: string): value is SearchFilterCollective {
+  return (COLLECTIVE_VALUES as string[]).includes(value);
+}
+
+// A `collective = <value>` (or `collective:<value>`) restriction anywhere in the
+// expression. The value may be bare (`soulection`) or quoted (`"soulection"`).
+const COLLECTIVE_RESTRICTION = /collective\s*[:=]\s*(?:"([^"]*)"|(\S+))/i;
+
+/**
+ * Parse an AIP-160-subset filter expression into structured search state.
+ * Unknown/unsupported syntax is treated as free text so nothing is ever lost.
+ */
+export function parseFilter(input: string): SearchFilter {
+  const filter: SearchFilter = { text: "", collective: null };
+  if (!input) return filter;
+
+  let remainder = input;
+
+  const match = remainder.match(COLLECTIVE_RESTRICTION);
+  if (match) {
+    const rawValue = (match[1] ?? match[2] ?? "").trim().toLowerCase();
+    if (isCollective(rawValue)) {
+      filter.collective = rawValue;
+      // Strip the restriction; whatever is left is the free-text query.
+      remainder =
+        remainder.slice(0, match.index) +
+        remainder.slice((match.index ?? 0) + match[0].length);
+    }
+  }
+
+  filter.text = remainder.replace(/\s+/g, " ").trim();
+  return filter;
+}
+
+/**
+ * Serialize structured search state back into an AIP-160-subset expression,
+ * suitable for a `?filter=` URL param. Returns an empty string when there is
+ * nothing to share (no query and no explicit collective), so callers can drop
+ * the param entirely and keep the URL clean.
+ */
+export function serializeFilter(filter: SearchFilter): string {
+  const parts: string[] = [];
+
+  if (filter.collective) {
+    parts.push(`collective = ${filter.collective}`);
+  }
+
+  const text = filter.text.trim();
+  if (text) {
+    parts.push(text);
+  }
+
+  return parts.join(" ");
+}

--- a/src/client/EpisodesScreen/useSearchUrlSync.ts
+++ b/src/client/EpisodesScreen/useSearchUrlSync.ts
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
+import { debounce } from "lodash-es";
+import { parseFilter, serializeFilter } from "./searchFilter";
+import { useCollectiveSelectStore, useNavbarStore } from "./Navbar";
+
+/**
+ * Owns the search query and keeps it in sync with a shareable `?filter=` URL
+ * (an AIP-160-subset expression — see {@link ./searchFilter}).
+ *
+ * On first load it hydrates from the URL: a deep link like
+ * `/?filter=collective = soulection missing you` restores the collective scope,
+ * pre-fills the query, and opens the search bar so the shared state is visible.
+ * As the user types or changes collective, the URL is updated (debounced, via
+ * `replace` + shallow routing) so it never spams history and never triggers a
+ * data refetch or scroll jump. Clearing the search returns the URL to a clean
+ * `/`.
+ */
+export function useSearchUrlSync(): {
+  searchText: string;
+  setSearchText: (text: string) => void;
+} {
+  const [searchText, setSearchText] = useState("");
+
+  const router = useRouter();
+  const collective = useCollectiveSelectStore((s) => s.selected);
+  const setCollective = useCollectiveSelectStore((s) => s.setSelected);
+  const openSearch = useNavbarStore((s) => s.openSearch);
+
+  // Only hydrate from the URL once; after that the UI is the source of truth.
+  const hydratedRef = useRef(false);
+
+  // The router object identity changes across renders, but `replace` always
+  // targets the live router — keep a ref so the debounced writer stays stable.
+  const routerRef = useRef(router);
+  routerRef.current = router;
+
+  const commit = useMemo(
+    () =>
+      debounce((filterStr: string) => {
+        const r = routerRef.current;
+        const url = filterStr
+          ? `${r.pathname}?filter=${encodeURIComponent(filterStr)}`
+          : r.pathname;
+        r.replace(url, undefined, { shallow: true });
+      }, 300),
+    [],
+  );
+
+  useEffect(() => () => commit.cancel(), [commit]);
+
+  // Hydrate state from the URL once the router has parsed the query string.
+  useEffect(() => {
+    if (!router.isReady || hydratedRef.current) return;
+    hydratedRef.current = true;
+
+    const raw =
+      typeof router.query.filter === "string" ? router.query.filter : "";
+    if (!raw) return;
+
+    const parsed = parseFilter(raw);
+    if (parsed.collective) {
+      setCollective(parsed.collective);
+    }
+    if (parsed.text) {
+      setSearchText(parsed.text);
+      openSearch();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady]);
+
+  // Mirror state back into the URL. The collective is only encoded while a
+  // query is active, so browsing without searching keeps the URL clean.
+  useEffect(() => {
+    if (!router.isReady || !hydratedRef.current) return;
+    const filterStr = serializeFilter({
+      text: searchText,
+      collective: searchText.trim() ? collective : null,
+    });
+    commit(filterStr);
+  }, [searchText, collective, router.isReady, commit]);
+
+  return { searchText, setSearchText };
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
-import { RefObject, createContext, useRef, useState } from "react";
+import { RefObject, createContext, useRef } from "react";
 import { EpisodesScreen } from "@/client/EpisodesScreen/EpisodesScreen";
+import { useSearchUrlSync } from "@/client/EpisodesScreen/useSearchUrlSync";
 import { useShortcutHandlers } from "@/client/useKeyboardHandlers";
 import Navbar from "@/client/EpisodesScreen/Navbar";
 import "react-spring-bottom-sheet/dist/style.css";
@@ -17,7 +18,7 @@ export const EpisodeListContext = createContext<EpisodeListContext>(
 );
 
 export default function Home() {
-  const [searchText, setSearchText] = useState("");
+  const { searchText, setSearchText } = useSearchUrlSync();
 
   const episodeListContextRef = useRef<EpisodeListHandle>(null);
   const focusEpisode = (episodeId: string) => {


### PR DESCRIPTION
Encode the active search into the URL as a single AIP-160-subset filter
expression (https://google.aip.dev/160): free-text terms plus an optional
`collective = <slug>` restriction, e.g. `/?filter=collective = soulection
missing you`. Baking the collective into the link means a shared URL
reproduces the exact results the sharer saw, regardless of the recipient's
saved collective.

- searchFilter.ts: parse/serialize the filter expression, structured to grow
  into richer restrictions (track:/name:/negation/date) without changing the
  URL contract.
- useSearchUrlSync.ts: hydrate search state from ?filter= on load (restoring
  scope, prefilling the query, and opening the search bar for a deep link),
  and mirror state back via debounced shallow replace so it never spams
  history or triggers a refetch. Clearing search returns the URL to a clean /.
- index.tsx: source searchText from the sync hook. UI is otherwise unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RW98HM86rgFWNTmUxcPXbV