### PR TITLE
Replace Mixcloud embed player with R2 archive streaming

### DIFF
--- a/src/client/EpisodesScreen/Player/index.tsx
+++ b/src/client/EpisodesScreen/Player/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { EmbedPlayer } from "../../components/EmbedPlayer";
 import {
   usePlayerActions,
   usePlayerPlaying,
@@ -51,15 +50,12 @@ export default function Player({ currentEpisodeId }: PlayerProps) {
     episodeModalSheetActions.open();
   }
 
-  const isSouncCloudSrc = currentEpisode.source === "SOUNDCLOUD";
-
   const isBiggerScreen = useMedia("(min-width: 768px)");
 
   const preferMiniPlayer = true;
-  const showEmbed = !isBiggerScreen && !preferMiniPlayer && isSouncCloudSrc;
 
-  const showMini = !isBiggerScreen && preferMiniPlayer && isSouncCloudSrc;
-  const showFullControls = isBiggerScreen && isSouncCloudSrc;
+  const showMini = !isBiggerScreen && preferMiniPlayer;
+  const showFullControls = isBiggerScreen;
 
   return (
     <>
@@ -73,16 +69,11 @@ export default function Player({ currentEpisodeId }: PlayerProps) {
           showMini && "h-0",
         )}
       >
-        {currentEpisode.source === "MIXCLOUD" && (
-          <div className="m-auto max-w-4xl">
-            <EmbedPlayer episode={currentEpisode} />
-          </div>
-        )}
         {!USE_NEW_PLAYER && (
           <SoundCloudPlayer
             key={currentEpisode.id}
             onReady={onSoundCloudPlayerReady}
-            showNative={showEmbed}
+            showNative={false}
             episode={currentEpisode}
             position={cuePosition}
             playing={playing}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -51,6 +51,7 @@ export type DBEpisode = {
     | "the-love-below-hour"
     | "local";
   tracks?: EpisodeTrack[];
+  archive_url?: string;
 };
 
 export type EpisodeProjection = ReturnType<typeof episodeProjectionFromDb>;
@@ -284,6 +285,27 @@ export const episodeRouter = router({
       timestamp: new Date().toISOString(),
     };
   }),
+  "internal.setArchiveUrl": authenticatedProcedure
+    .input(
+      z.object({
+        episodeId: z.string(),
+        archiveUrl: z.string().url(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const trackCollection = ctx.db.collection<DBEpisode>("tracksOld");
+      const result = await trackCollection.updateOne(
+        { _id: new ObjectId(input.episodeId) },
+        { $set: { archive_url: input.archiveUrl } },
+      );
+      if (result.matchedCount === 0) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Episode ${input.episodeId} not found`,
+        });
+      }
+      return { success: true, episodeId: input.episodeId };
+    }),
   "episodes.all": publicProcedure
     .input(
       z.optional(
@@ -413,6 +435,16 @@ export const episodeRouter = router({
 
       if (!episode) {
         return null;
+      }
+
+      if (episode.source === "MIXCLOUD") {
+        if (!episode.archive_url) return null;
+        return {
+          http_mp3_128_url: episode.archive_url,
+          hls_mp3_128_url: episode.archive_url,
+          hls_opus_64_url: episode.archive_url,
+          preview_mp3_128_url: episode.archive_url,
+        } satisfies GetStreamUrlsDTO;
       }
 
       const scTrackId = `${episode.key}`;

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -285,26 +285,29 @@ export const episodeRouter = router({
       timestamp: new Date().toISOString(),
     };
   }),
-  "internal.setArchiveUrl": authenticatedProcedure
+  "internal.bulkSetArchiveUrls": authenticatedProcedure
     .input(
-      z.object({
-        episodeId: z.string(),
-        archiveUrl: z.string().url(),
-      }),
+      z.array(
+        z.object({
+          episodeId: z.string(),
+          archiveUrl: z.string().url(),
+        }),
+      ),
     )
     .mutation(async ({ ctx, input }) => {
       const trackCollection = ctx.db.collection<DBEpisode>("tracksOld");
-      const result = await trackCollection.updateOne(
-        { _id: new ObjectId(input.episodeId) },
-        { $set: { archive_url: input.archiveUrl } },
+      const result = await trackCollection.bulkWrite(
+        input.map(({ episodeId, archiveUrl }) => ({
+          updateOne: {
+            filter: { _id: new ObjectId(episodeId) },
+            update: { $set: { archive_url: archiveUrl } },
+          },
+        })),
       );
-      if (result.matchedCount === 0) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `Episode ${input.episodeId} not found`,
-        });
-      }
-      return { success: true, episodeId: input.episodeId };
+      return {
+        matched: result.matchedCount,
+        modified: result.modifiedCount,
+      };
     }),
   "episodes.all": publicProcedure
     .input(


### PR DESCRIPTION
## Summary

- Mixcloud episodes now stream from the R2 archive at `archive.jalvarado.dev` instead of showing the Mixcloud embed widget
- `episode.getStreamUrl` returns the R2 `archive_url` directly when set on a Mixcloud episode; returns `null` for unarchived episodes (the 9 that weren't available on Mixcloud)
- Adds `internal.setArchiveUrl` authenticated tRPC mutation for the one-time backfill script that will populate `archive_url` on all 175 archived episodes in MongoDB
- Removes `EmbedPlayer` from the player — all episodes now use the native `AudioPlayer`
- Player controls (full and mini) now render for all episode sources, not just SoundCloud

## After merging

Run the backfill script from the archive server to populate `archive_url` on all episodes:

```bash
cd ~/mixcloud-archival
INTERNAL_AUTH_USERNAME=... INTERNAL_AUTH_PASSWORD=... node backfill-archive-urls.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JW3uoPzT4zEqp9jeuRGNAV