### PR TITLE
Fix bulk archive URL input schema for tRPC v10

### DIFF
--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -287,17 +287,19 @@ export const episodeRouter = router({
   }),
   "internal.bulkSetArchiveUrls": authenticatedProcedure
     .input(
-      z.array(
-        z.object({
-          episodeId: z.string(),
-          archiveUrl: z.string().url(),
-        }),
-      ),
+      z.object({
+        episodes: z.array(
+          z.object({
+            episodeId: z.string(),
+            archiveUrl: z.string().url(),
+          }),
+        ),
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const trackCollection = ctx.db.collection<DBEpisode>("tracksOld");
       const result = await trackCollection.bulkWrite(
-        input.map(({ episodeId, archiveUrl }) => ({
+        input.episodes.map(({ episodeId, archiveUrl }) => ({
           updateOne: {
             filter: { _id: new ObjectId(episodeId) },
             update: { $set: { archive_url: archiveUrl } },


### PR DESCRIPTION
tRPC v10 doesn't handle arrays as the root mutation input correctly. Wraps the episodes array in an object (`{ episodes: [...] }`) to fix the HTTP 400 error from the backfill script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JW3uoPzT4zEqp9jeuRGNAV