### PR TITLE
Add CI workflow to build unsigned iOS IPA for sideloading

### DIFF
--- a/.github/workflows/ios-sideload.yml
+++ b/.github/workflows/ios-sideload.yml
@@ -1,0 +1,63 @@
+name: iOS Sideload Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - claude/mobile-app-expiration-remote-build-wsf3of
+    paths:
+      - "ios/**"
+      - ".github/workflows/ios-sideload.yml"
+
+concurrency:
+  group: ios-sideload
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build unsigned IPA
+    runs-on: macos-15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build archive (unsigned)
+        run: |
+          xcodebuild archive \
+            -project ios/Soulector.xcodeproj \
+            -scheme Soulector \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath build/Soulector.xcarchive \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""
+
+      - name: Package IPA
+        run: |
+          mkdir -p build/Payload
+          cp -R "build/Soulector.xcarchive/Products/Applications/Soulector.app" build/Payload/
+          cd build
+          zip -qry Soulector.ipa Payload
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Soulector-ipa
+          path: build/Soulector.ipa
+
+      - name: Publish rolling release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: sideload-latest
+          name: Soulector iOS (latest sideload build)
+          body: |
+            Unsigned IPA for sideloading with SideStore.
+
+            Built from `${{ github.sha }}` on `${{ github.ref_name }}`.
+
+            **Install on iPhone:** download `Soulector.ipa` below in Safari,
+            then open SideStore → My Apps → + → pick the downloaded file.
+          files: build/Soulector.ipa

--- a/.github/workflows/ios-sideload.yml
+++ b/.github/workflows/ios-sideload.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - claude/mobile-app-expiration-remote-build-wsf3of
     paths:
       - "ios/**"
       - ".github/workflows/ios-sideload.yml"

--- a/ios/Soulector.xcodeproj/xcshareddata/xcschemes/Soulector.xcscheme
+++ b/ios/Soulector.xcodeproj/xcshareddata/xcschemes/Soulector.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AE000001"
+               BuildableName = "Soulector.app"
+               BlueprintName = "Soulector"
+               ReferencedContainer = "container:Soulector.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE000001"
+            BuildableName = "Soulector.app"
+            BlueprintName = "Soulector"
+            ReferencedContainer = "container:Soulector.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE000001"
+            BuildableName = "Soulector.app"
+            BlueprintName = "Soulector"
+            ReferencedContainer = "container:Soulector.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the Soulector iOS app **unsigned** on a macOS runner and publishes the IPA to a rolling `sideload-latest` GitHub release, for installing on-device via SideStore (which re-signs with a free Apple ID and auto-refreshes the 7-day provisioning window).

## Changes

- **`.github/workflows/ios-sideload.yml`** — builds `Soulector.xcodeproj` with `CODE_SIGNING_ALLOWED=NO`, packages the `.app` into `Soulector.ipa`, uploads it as a run artifact, and publishes it to the `sideload-latest` release. Triggers: manual `workflow_dispatch`, and pushes to `main` touching `ios/**`.
- **`ios/Soulector.xcodeproj/xcshareddata/xcschemes/Soulector.xcscheme`** — shared Xcode scheme so `xcodebuild` can resolve the `Soulector` scheme in CI (schemes are user-local until shared).

## Stable install URL

https://github.com/biensupernice/soulector/releases/download/sideload-latest/Soulector.ipa

## Verified

Run [#1](https://github.com/biensupernice/soulector/actions/runs/29221257088) built green from this branch and published the release; the IPA installs and runs via SideStore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EE7zRrQpppwazzZ4VBnA48

---
_Generated by [Claude Code](https://claude.ai/code/session_01EE7zRrQpppwazzZ4VBnA48)_