### PR TITLE
Center active track in tracks container and constrain its height on mobile

### DIFF
--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "../PlayerStore";
 import { useGetEpisode } from "../useEpisodeHooks";
 import Sheet from "react-modal-sheet";
+import { useEffect, useRef } from "react";
 import create from "zustand";
 import { trpc } from "@/utils/trpc";
 import { cn } from "@/lib/utils";
@@ -75,6 +76,7 @@ export function EpisodeModalSheet({
 
 function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
   const episode = useGetEpisode(episodeId);
+  const { hasTracks } = useEpisodeTracks(episodeId);
 
   return (
     <div className="relative flex h-full w-full flex-col items-center justify-between space-y-3 overflow-auto pb-safe-top">
@@ -109,10 +111,14 @@ function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
         </a>
         <EpisodeSheetFavoriteToggle episodeId={episodeId} />
       </div>
-      <div className="xs:slide-in-from-bottom-3 md:fade-in animate-in rounded-lg duration-600 relative mx-3">
-        <div className="absolute rounded-lg inset-0 bg-black/20"></div>
-        <EpisodeTracksList episodeId={episodeId} />
-      </div>
+      {hasTracks && (
+        <div className="xs:slide-in-from-bottom-3 md:fade-in animate-in rounded-lg duration-600 relative mx-3 flex min-h-[10rem] flex-col self-stretch">
+          <div className="absolute rounded-lg inset-0 bg-black/20"></div>
+          <div className="relative min-h-0 overflow-y-auto">
+            <EpisodeTracksList episodeId={episodeId} />
+          </div>
+        </div>
+      )}
       <br />
     </div>
   );
@@ -135,6 +141,21 @@ export function useEpisodeTracks(episodeId: string, enabled: boolean = true) {
     loaded: status === "success",
     hasTracks: status === "success" && data.length > 0,
   };
+}
+
+function getScrollParent(el: HTMLElement): HTMLElement | null {
+  let node = el.parentElement;
+  while (node) {
+    const overflowY = getComputedStyle(node).overflowY;
+    if (
+      (overflowY === "auto" || overflowY === "scroll") &&
+      node.scrollHeight > node.clientHeight
+    ) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
 }
 
 export function EpisodeTracksList({ episodeId }: { episodeId: string }) {
@@ -160,6 +181,45 @@ export function EpisodeTracksList({ episodeId }: { episodeId: string }) {
   );
 
   const currentTrack = possibleTracks.at(-1);
+  const currentTrackOrder = currentTrack?.order;
+
+  const currentTrackRef = useRef<HTMLButtonElement | null>(null);
+  const hasCenteredRef = useRef(false);
+
+  useEffect(() => {
+    if (currentTrackOrder == null) {
+      return;
+    }
+
+    function centerCurrentTrack(behavior: ScrollBehavior) {
+      const el = currentTrackRef.current;
+      if (!el) return;
+      const container = getScrollParent(el);
+      if (!container) return;
+      const containerRect = container.getBoundingClientRect();
+      const elRect = el.getBoundingClientRect();
+      const delta =
+        elRect.top -
+        containerRect.top -
+        (container.clientHeight - elRect.height) / 2;
+      container.scrollTo({
+        top: container.scrollTop + delta,
+        behavior,
+      });
+    }
+
+    const isFirstCenter = !hasCenteredRef.current;
+    hasCenteredRef.current = true;
+    centerCurrentTrack(isFirstCenter ? "auto" : "smooth");
+
+    // on desktop the tracks panel animates open, so the container may not
+    // have its final height yet on first render; re-center once it settles
+    let timeout: number | undefined;
+    if (isFirstCenter) {
+      timeout = window.setTimeout(() => centerCurrentTrack("auto"), 350);
+    }
+    return () => window.clearTimeout(timeout);
+  }, [currentTrackOrder]);
 
   function onTrackClick(t: EpisodeTrackProjection) {
     if (t.timestamp) {
@@ -180,6 +240,8 @@ export function EpisodeTracksList({ episodeId }: { episodeId: string }) {
             const isCurrent = currentTrack?.order === t.order;
             return (
               <button
+                key={`${t.order}-${i}`}
+                ref={isCurrent ? currentTrackRef : undefined}
                 onClick={() => onTrackClick(t)}
                 className={cn("w-full relative hover:bg-white/10")}
               >

--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "../PlayerStore";
 import { useGetEpisode } from "../useEpisodeHooks";
 import Sheet from "react-modal-sheet";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import create from "zustand";
 import { trpc } from "@/utils/trpc";
 import { cn } from "@/lib/utils";
@@ -74,25 +74,72 @@ export function EpisodeModalSheet({
   );
 }
 
+type TracksAreaVariant = "fit" | "half" | "full";
+
+const tracksAreaVariants: { id: TracksAreaVariant; label: string }[] = [
+  { id: "fit", label: "Fit" },
+  { id: "half", label: "Half" },
+  { id: "full", label: "Full" },
+];
+
+const tracksAreaVariantStorageKey = "soulector:tracks-area-variant";
+
+function useTracksAreaVariant() {
+  const [variant, setVariant] = useState<TracksAreaVariant>("fit");
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(tracksAreaVariantStorageKey);
+    if (tracksAreaVariants.some((v) => v.id === saved)) {
+      setVariant(saved as TracksAreaVariant);
+    }
+  }, []);
+
+  function changeVariant(next: TracksAreaVariant) {
+    setVariant(next);
+    window.localStorage.setItem(tracksAreaVariantStorageKey, next);
+  }
+
+  return [variant, changeVariant] as const;
+}
+
 function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
   const episode = useGetEpisode(episodeId);
   const { hasTracks } = useEpisodeTracks(episodeId);
+  const [tracksVariant, setTracksVariant] = useTracksAreaVariant();
+
+  const showCompactHeader = hasTracks && tracksVariant === "full";
 
   return (
     <div className="relative flex h-full w-full flex-col items-center justify-between space-y-3 overflow-auto pb-safe-top">
-      <div className="w-full flex-col space-y-3 px-4 md:px-6 pt-6">
-        <img
-          className="min-h-40 min-w-40 mx-auto w-full max-w-sm rounded-lg object-fill"
-          src={episode.artworkUrl}
-          alt={episode.name}
-        />
-        <div className="flex w-full flex-col text-center">
-          <div className="font-bold text-white">{episode.name}</div>
-          <div className="text-sm text-white/80">
-            {formatDate(episode.releasedAt)}
+      {showCompactHeader ? (
+        <div className="flex w-full items-center space-x-3 px-4 pt-6">
+          <img
+            className="h-14 w-14 shrink-0 rounded-lg object-cover"
+            src={episode.artworkUrl}
+            alt={episode.name}
+          />
+          <div className="min-w-0 flex-1 text-left">
+            <div className="truncate font-bold text-white">{episode.name}</div>
+            <div className="text-sm text-white/80">
+              {formatDate(episode.releasedAt)}
+            </div>
           </div>
         </div>
-      </div>
+      ) : (
+        <div className="w-full flex-col space-y-3 px-4 md:px-6 pt-6">
+          <img
+            className="min-h-40 min-w-40 mx-auto w-full max-w-sm rounded-lg object-fill"
+            src={episode.artworkUrl}
+            alt={episode.name}
+          />
+          <div className="flex w-full flex-col text-center">
+            <div className="font-bold text-white">{episode.name}</div>
+            <div className="text-sm text-white/80">
+              {formatDate(episode.releasedAt)}
+            </div>
+          </div>
+        </div>
+      )}
       <div className="w-full px-6">
         <EpisodeSheetPlayer episodeId={episodeId} />
       </div>
@@ -112,12 +159,40 @@ function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
         <EpisodeSheetFavoriteToggle episodeId={episodeId} />
       </div>
       {hasTracks && (
-        <div className="xs:slide-in-from-bottom-3 md:fade-in animate-in rounded-lg duration-600 relative mx-3 flex min-h-[10rem] flex-col self-stretch">
-          <div className="absolute rounded-lg inset-0 bg-black/20"></div>
-          <div className="relative min-h-0 overflow-y-auto">
-            <EpisodeTracksList episodeId={episodeId} />
+        <>
+          <div className="flex w-full items-center justify-between px-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-white/70">
+              Tracks layout
+            </div>
+            <div className="flex rounded-full bg-black/20 p-0.5">
+              {tracksAreaVariants.map((v) => (
+                <button
+                  key={v.id}
+                  onClick={() => setTracksVariant(v.id)}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-xs font-semibold text-white/70",
+                    tracksVariant === v.id && "bg-white !text-accent",
+                  )}
+                >
+                  {v.label}
+                </button>
+              ))}
+            </div>
           </div>
-        </div>
+          <div
+            className={cn(
+              "xs:slide-in-from-bottom-3 md:fade-in animate-in rounded-lg duration-600 relative mx-3 flex flex-col self-stretch",
+              tracksVariant === "fit" && "min-h-[12rem]",
+              tracksVariant === "half" && "h-1/2 min-h-[14rem] shrink-0",
+              tracksVariant === "full" && "min-h-[16rem] flex-1",
+            )}
+          >
+            <div className="absolute rounded-lg inset-0 bg-black/20"></div>
+            <div className="relative min-h-0 overflow-y-auto">
+              <EpisodeTracksList key={tracksVariant} episodeId={episodeId} />
+            </div>
+          </div>
+        </>
       )}
       <br />
     </div>

--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -2,6 +2,10 @@ import {
   IconSoundcloud,
   HeartFilled,
   HeartOutline,
+  IconPlay,
+  IconPause,
+  IconBackThirty,
+  IconSkipThirty,
 } from "@/client/components/Icons";
 import { formatDate, formatTimeSecs } from "@/client/helpers";
 import classNames from "classnames";
@@ -74,18 +78,19 @@ export function EpisodeModalSheet({
   );
 }
 
-type TracksAreaVariant = "fit" | "half" | "full";
+type TracksAreaVariant = "half" | "tall" | "full" | "morph";
 
 const tracksAreaVariants: { id: TracksAreaVariant; label: string }[] = [
-  { id: "fit", label: "Fit" },
   { id: "half", label: "Half" },
+  { id: "tall", label: "Tall" },
   { id: "full", label: "Full" },
+  { id: "morph", label: "Morph" },
 ];
 
 const tracksAreaVariantStorageKey = "soulector:tracks-area-variant";
 
 function useTracksAreaVariant() {
-  const [variant, setVariant] = useState<TracksAreaVariant>("fit");
+  const [variant, setVariant] = useState<TracksAreaVariant>("half");
 
   useEffect(() => {
     const saved = window.localStorage.getItem(tracksAreaVariantStorageKey);
@@ -102,31 +107,328 @@ function useTracksAreaVariant() {
   return [variant, changeVariant] as const;
 }
 
-function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
+function TracksVariantSwitcher({
+  variant,
+  onChange,
+}: {
+  variant: TracksAreaVariant;
+  onChange: (v: TracksAreaVariant) => void;
+}) {
+  return (
+    <div className="flex w-full items-center justify-between px-4">
+      <div className="text-xs font-semibold uppercase tracking-wide text-white/70">
+        Tracks layout
+      </div>
+      <div className="flex rounded-full bg-black/20 p-0.5">
+        {tracksAreaVariants.map((v) => (
+          <button
+            key={v.id}
+            onClick={() => onChange(v.id)}
+            className={cn(
+              "rounded-full px-2.5 py-1 text-xs font-semibold text-white/70",
+              variant === v.id && "bg-white !text-accent",
+            )}
+          >
+            {v.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EpisodeSheetCompactTitle({ episodeId }: { episodeId: string }) {
   const episode = useGetEpisode(episodeId);
+  return (
+    <div className="flex w-full items-center space-x-3 px-4">
+      <img
+        className="h-12 w-12 shrink-0 rounded-md object-cover"
+        src={episode.artworkUrl}
+        alt={episode.name}
+      />
+      <div className="min-w-0 flex-1 text-left">
+        <div className="truncate font-bold text-white">{episode.name}</div>
+        <div className="text-sm text-white/80">
+          {formatDate(episode.releasedAt)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CompactSheetPlayerControls() {
+  const playing = usePlayerPlaying();
+  const loadingStatus = usePlayerLoadingStatus();
+  const playerActions = usePlayerActions();
+  const loading = loadingStatus === "loading";
+
+  return (
+    <div className="flex shrink-0 items-center space-x-1">
+      <button
+        title="Rewind 30 seconds"
+        onClick={() => playerActions.rewind(30)}
+        className="rounded-full p-1 text-white hover:text-white/80 focus:outline-none"
+      >
+        <IconBackThirty className="h-7 w-7 fill-current" />
+      </button>
+      <button
+        disabled={loading}
+        onClick={() => (playing ? playerActions.pause() : playerActions.resume())}
+        className="rounded-full bg-white p-2 leading-none text-accent shadow-md focus:outline-none"
+      >
+        {loading ? (
+          <svg
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6 animate-ping p-1"
+          >
+            <circle cx="10" cy="10" r="9" fill="currentColor" />
+          </svg>
+        ) : playing ? (
+          <IconPause className="h-6 w-6 fill-current" />
+        ) : (
+          <IconPlay className="h-6 w-6 fill-current" />
+        )}
+      </button>
+      <button
+        title="Forward 30 seconds"
+        onClick={() => playerActions.forward(30)}
+        className="rounded-full p-1 text-white hover:text-white/80 focus:outline-none"
+      >
+        <IconSkipThirty className="h-7 w-7 fill-current" />
+      </button>
+    </div>
+  );
+}
+
+function PlayerProgressHairline() {
+  const progress = usePlayerProgress();
+  const episodeDuration = usePlayerEpisodeDuration();
+  const pct =
+    episodeDuration > 0 ? Math.min(100, (progress / episodeDuration) * 100) : 0;
+
+  return (
+    <div className="h-0.5 w-full bg-white/20">
+      <div className="h-full bg-white/90" style={{ width: `${pct}%` }} />
+    </div>
+  );
+}
+
+function EpisodeSheetActionButtons({ episodeId }: { episodeId: string }) {
+  const episode = useGetEpisode(episodeId);
+  return (
+    <div className="grid w-full grid-cols-2 gap-x-2 px-4">
+      <a
+        href={episode.permalinkUrl}
+        className="inline-flex w-full flex-1 items-center justify-center space-x-1 rounded-md border-2 border-white bg-transparent px-2 py-1 text-center text-xs font-semibold text-white"
+      >
+        <span
+          className={classNames("inline-block rounded-full p-1")}
+          title="Open in SoundCloud"
+        >
+          <IconSoundcloud className="h-4 w-4 fill-current" />
+        </span>
+        <span>Open in SoundCloud</span>
+      </a>
+      <EpisodeSheetFavoriteToggle episodeId={episodeId} />
+    </div>
+  );
+}
+
+function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
   const { hasTracks } = useEpisodeTracks(episodeId);
   const [tracksVariant, setTracksVariant] = useTracksAreaVariant();
 
-  const showCompactHeader = hasTracks && tracksVariant === "full";
+  if (hasTracks && tracksVariant === "full") {
+    return (
+      <EpisodeSheetFullContent
+        episodeId={episodeId}
+        switcher={
+          <TracksVariantSwitcher
+            variant={tracksVariant}
+            onChange={setTracksVariant}
+          />
+        }
+      />
+    );
+  }
+
+  if (hasTracks && tracksVariant === "morph") {
+    return (
+      <EpisodeSheetMorphContent
+        episodeId={episodeId}
+        switcher={
+          <TracksVariantSwitcher
+            variant={tracksVariant}
+            onChange={setTracksVariant}
+          />
+        }
+      />
+    );
+  }
+
+  return (
+    <EpisodeSheetStackedContent
+      episodeId={episodeId}
+      variant={tracksVariant}
+      switcher={
+        <TracksVariantSwitcher
+          variant={tracksVariant}
+          onChange={setTracksVariant}
+        />
+      }
+    />
+  );
+}
+
+/**
+ * "Half" / "Tall" variants (also the fallback when the episode has no
+ * tracks): full artwork, player, and action buttons stacked, with the
+ * tracks area taking a fixed share of the sheet height.
+ */
+function EpisodeSheetStackedContent({
+  episodeId,
+  variant,
+  switcher,
+}: {
+  episodeId: string;
+  variant: TracksAreaVariant;
+  switcher: React.ReactNode;
+}) {
+  const episode = useGetEpisode(episodeId);
+  const { hasTracks } = useEpisodeTracks(episodeId);
 
   return (
     <div className="relative flex h-full w-full flex-col items-center justify-between space-y-3 overflow-auto pb-safe-top">
-      {showCompactHeader ? (
-        <div className="flex w-full items-center space-x-3 px-4 pt-6">
+      <div className="w-full flex-col space-y-3 px-4 md:px-6 pt-6">
+        <img
+          className="min-h-40 min-w-40 mx-auto w-full max-w-sm rounded-lg object-fill"
+          src={episode.artworkUrl}
+          alt={episode.name}
+        />
+        <div className="flex w-full flex-col text-center">
+          <div className="font-bold text-white">{episode.name}</div>
+          <div className="text-sm text-white/80">
+            {formatDate(episode.releasedAt)}
+          </div>
+        </div>
+      </div>
+      <div className="w-full px-6">
+        <EpisodeSheetPlayer episodeId={episodeId} />
+      </div>
+      <EpisodeSheetActionButtons episodeId={episodeId} />
+      {hasTracks && (
+        <>
+          {switcher}
+          <div
+            className={cn(
+              "relative mx-3 flex shrink-0 flex-col self-stretch rounded-lg",
+              variant === "tall"
+                ? "h-[62%] min-h-[16rem]"
+                : "h-1/2 min-h-[14rem]",
+            )}
+          >
+            <div className="absolute rounded-lg inset-0 bg-black/20"></div>
+            <div className="relative min-h-0 overflow-y-auto">
+              <EpisodeTracksList key={variant} episodeId={episodeId} />
+            </div>
+          </div>
+        </>
+      )}
+      <br />
+    </div>
+  );
+}
+
+/**
+ * "Full" variant: the tracks take all the space between a compact title
+ * row at the top and the untouched full player controls docked at the
+ * bottom.
+ */
+function EpisodeSheetFullContent({
+  episodeId,
+  switcher,
+}: {
+  episodeId: string;
+  switcher: React.ReactNode;
+}) {
+  return (
+    <div className="relative flex h-full w-full flex-col space-y-3 overflow-hidden pb-safe-top pt-4">
+      <EpisodeSheetCompactTitle episodeId={episodeId} />
+      {switcher}
+      <div className="relative mx-3 flex min-h-0 flex-1 flex-col rounded-lg">
+        <div className="absolute rounded-lg inset-0 bg-black/20"></div>
+        <div className="relative min-h-0 overflow-y-auto">
+          <EpisodeTracksList episodeId={episodeId} />
+        </div>
+      </div>
+      <div className="w-full px-6">
+        <EpisodeSheetPlayer episodeId={episodeId} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * "Morph" variant: the sheet scrolls as one column, and once the user
+ * scrolls past the artwork a compact header (thumbnail, title, inline
+ * player controls, progress hairline) slides in over the top, leaving
+ * the rest of the sheet to the tracks.
+ */
+function EpisodeSheetMorphContent({
+  episodeId,
+  switcher,
+}: {
+  episodeId: string;
+  switcher: React.ReactNode;
+}) {
+  const episode = useGetEpisode(episodeId);
+  const [collapsed, setCollapsed] = useState(false);
+
+  function onSheetScroll(e: React.UIEvent<HTMLDivElement>) {
+    const top = e.currentTarget.scrollTop;
+    // hysteresis so the header doesn't flicker around the threshold
+    setCollapsed((c) => (c ? top > 150 : top > 190));
+  }
+
+  return (
+    <div className="relative h-full w-full overflow-hidden">
+      <div
+        className={cn(
+          "absolute inset-x-0 top-0 z-10 bg-accent transition-all duration-300",
+          collapsed
+            ? "translate-y-0 opacity-100"
+            : "pointer-events-none -translate-y-3 opacity-0",
+        )}
+      >
+        <div className="flex w-full items-center space-x-3 px-4 py-2">
           <img
-            className="h-14 w-14 shrink-0 rounded-lg object-cover"
+            className="h-12 w-12 shrink-0 rounded-md object-cover"
             src={episode.artworkUrl}
             alt={episode.name}
           />
           <div className="min-w-0 flex-1 text-left">
-            <div className="truncate font-bold text-white">{episode.name}</div>
-            <div className="text-sm text-white/80">
+            <div className="truncate text-sm font-bold text-white">
+              {episode.name}
+            </div>
+            <div className="text-xs text-white/80">
               {formatDate(episode.releasedAt)}
             </div>
           </div>
+          <CompactSheetPlayerControls />
         </div>
-      ) : (
-        <div className="w-full flex-col space-y-3 px-4 md:px-6 pt-6">
+        <PlayerProgressHairline />
+      </div>
+      <div
+        onScroll={onSheetScroll}
+        className="flex h-full w-full flex-col items-center space-y-3 overflow-y-auto pb-safe-top"
+      >
+        <div
+          className={cn(
+            "w-full flex-col space-y-3 px-4 pt-6 transition-all duration-300",
+            collapsed && "scale-95 opacity-0",
+          )}
+        >
           <img
             className="min-h-40 min-w-40 mx-auto w-full max-w-sm rounded-lg object-fill"
             src={episode.artworkUrl}
@@ -139,62 +441,24 @@ function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
             </div>
           </div>
         </div>
-      )}
-      <div className="w-full px-6">
-        <EpisodeSheetPlayer episodeId={episodeId} />
-      </div>
-      <div className="grid w-full grid-cols-2 gap-x-2 px-4">
-        <a
-          href={episode.permalinkUrl}
-          className="inline-flex w-full flex-1 items-center justify-center space-x-1 rounded-md border-2 border-white bg-transparent px-2 py-1 text-center text-xs font-semibold text-white"
+        <div
+          className={cn(
+            "w-full px-6 transition-opacity duration-300",
+            collapsed && "opacity-0",
+          )}
         >
-          <span
-            className={classNames("inline-block rounded-full p-1")}
-            title="Open in SoundCloud"
-          >
-            <IconSoundcloud className="h-4 w-4 fill-current" />
-          </span>
-          <span>Open in SoundCloud</span>
-        </a>
-        <EpisodeSheetFavoriteToggle episodeId={episodeId} />
+          <EpisodeSheetPlayer episodeId={episodeId} />
+        </div>
+        <EpisodeSheetActionButtons episodeId={episodeId} />
+        {switcher}
+        <div className="relative mx-3 self-stretch rounded-lg">
+          <div className="absolute rounded-lg inset-0 bg-black/20"></div>
+          <div className="relative">
+            <EpisodeTracksList episodeId={episodeId} />
+          </div>
+        </div>
+        <br />
       </div>
-      {hasTracks && (
-        <>
-          <div className="flex w-full items-center justify-between px-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-white/70">
-              Tracks layout
-            </div>
-            <div className="flex rounded-full bg-black/20 p-0.5">
-              {tracksAreaVariants.map((v) => (
-                <button
-                  key={v.id}
-                  onClick={() => setTracksVariant(v.id)}
-                  className={cn(
-                    "rounded-full px-3 py-1 text-xs font-semibold text-white/70",
-                    tracksVariant === v.id && "bg-white !text-accent",
-                  )}
-                >
-                  {v.label}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div
-            className={cn(
-              "xs:slide-in-from-bottom-3 md:fade-in animate-in rounded-lg duration-600 relative mx-3 flex flex-col self-stretch",
-              tracksVariant === "fit" && "min-h-[12rem]",
-              tracksVariant === "half" && "h-1/2 min-h-[14rem] shrink-0",
-              tracksVariant === "full" && "min-h-[16rem] flex-1",
-            )}
-          >
-            <div className="absolute rounded-lg inset-0 bg-black/20"></div>
-            <div className="relative min-h-0 overflow-y-auto">
-              <EpisodeTracksList key={tracksVariant} episodeId={episodeId} />
-            </div>
-          </div>
-        </>
-      )}
-      <br />
     </div>
   );
 }

--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -19,8 +19,7 @@ import {
 } from "../PlayerStore";
 import { useGetEpisode } from "../useEpisodeHooks";
 import Sheet from "react-modal-sheet";
-import { motion } from "framer-motion";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import create from "zustand";
 import { trpc } from "@/utils/trpc";
 import { cn } from "@/lib/utils";
@@ -75,121 +74,7 @@ export function EpisodeModalSheet({
   );
 }
 
-type TracksAreaVariant = "half" | "morph";
-
-const tracksAreaVariants: { id: TracksAreaVariant; label: string }[] = [
-  { id: "half", label: "Half" },
-  { id: "morph", label: "Morph" },
-];
-
-const tracksAreaVariantStorageKey = "soulector:tracks-area-variant";
-
-function useTracksAreaVariant() {
-  const [variant, setVariant] = useState<TracksAreaVariant>("half");
-
-  useEffect(() => {
-    const saved = window.localStorage.getItem(tracksAreaVariantStorageKey);
-    if (tracksAreaVariants.some((v) => v.id === saved)) {
-      setVariant(saved as TracksAreaVariant);
-    }
-  }, []);
-
-  function changeVariant(next: TracksAreaVariant) {
-    setVariant(next);
-    window.localStorage.setItem(tracksAreaVariantStorageKey, next);
-  }
-
-  return [variant, changeVariant] as const;
-}
-
-function TracksVariantSwitcher({
-  variant,
-  onChange,
-}: {
-  variant: TracksAreaVariant;
-  onChange: (v: TracksAreaVariant) => void;
-}) {
-  return (
-    <div className="flex w-full items-center justify-between px-4">
-      <div className="text-xs font-semibold uppercase tracking-wide text-white/70">
-        Tracks layout
-      </div>
-      <div className="flex rounded-full bg-black/20 p-0.5">
-        {tracksAreaVariants.map((v) => (
-          <button
-            key={v.id}
-            onClick={() => onChange(v.id)}
-            className={cn(
-              "rounded-full px-2.5 py-1 text-xs font-semibold text-white/70",
-              variant === v.id && "bg-white !text-accent",
-            )}
-          >
-            {v.label}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function EpisodeSheetActionButtons({ episodeId }: { episodeId: string }) {
-  const episode = useGetEpisode(episodeId);
-  return (
-    <div className="grid w-full grid-cols-2 gap-x-2 px-4">
-      <a
-        href={episode.permalinkUrl}
-        className="inline-flex w-full flex-1 items-center justify-center space-x-1 rounded-md border-2 border-white bg-transparent px-2 py-1 text-center text-xs font-semibold text-white"
-      >
-        <span
-          className={classNames("inline-block rounded-full p-1")}
-          title="Open in SoundCloud"
-        >
-          <IconSoundcloud className="h-4 w-4 fill-current" />
-        </span>
-        <span>Open in SoundCloud</span>
-      </a>
-      <EpisodeSheetFavoriteToggle episodeId={episodeId} />
-    </div>
-  );
-}
-
 function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
-  const { hasTracks } = useEpisodeTracks(episodeId);
-  const [tracksVariant, setTracksVariant] = useTracksAreaVariant();
-
-  const switcher = (
-    <TracksVariantSwitcher
-      variant={tracksVariant}
-      onChange={setTracksVariant}
-    />
-  );
-
-  if (hasTracks && tracksVariant === "morph") {
-    return (
-      <EpisodeSheetMorphDetailsContent
-        episodeId={episodeId}
-        switcher={switcher}
-      />
-    );
-  }
-
-  return (
-    <EpisodeSheetStackedContent episodeId={episodeId} switcher={switcher} />
-  );
-}
-
-/**
- * "Half" variant (also the fallback when the episode has no tracks):
- * full artwork, player, and action buttons stacked, with the tracks
- * area taking half the sheet height.
- */
-function EpisodeSheetStackedContent({
-  episodeId,
-  switcher,
-}: {
-  episodeId: string;
-  switcher: React.ReactNode;
-}) {
   const episode = useGetEpisode(episodeId);
   const { hasTracks } = useEpisodeTracks(episodeId);
 
@@ -211,161 +96,29 @@ function EpisodeSheetStackedContent({
       <div className="w-full px-6">
         <EpisodeSheetPlayer episodeId={episodeId} />
       </div>
-      <EpisodeSheetActionButtons episodeId={episodeId} />
-      {hasTracks && (
-        <>
-          {switcher}
-          <div className="relative mx-3 flex h-1/2 min-h-[14rem] shrink-0 flex-col self-stretch rounded-lg">
-            <div className="absolute rounded-lg inset-0 bg-black/20"></div>
-            <div className="relative min-h-0 overflow-y-auto">
-              <EpisodeTracksList episodeId={episodeId} />
-            </div>
-          </div>
-        </>
-      )}
-      <br />
-    </div>
-  );
-}
-
-const detailsMorphTransition = {
-  type: "spring",
-  bounce: 0.15,
-  duration: 0.45,
-} as const;
-
-/**
- * "Morph" variant: same layout as "Half", but the user scrolling the
- * tracks list collapses the episode details into a compact thumbnail
- * row, and the tracks area grows into the freed space. The artwork and
- * title are shared elements (framer-motion layoutId) that travel
- * between their expanded and compact positions, while the player,
- * buttons, and tracks glide along via position layout animations.
- * Driven by user scroll direction only: scrolling down collapses,
- * scrolling up (or reaching the top) expands, and the list's own
- * programmatic active-track centering never toggles it.
- */
-function EpisodeSheetMorphDetailsContent({
-  episodeId,
-  switcher,
-}: {
-  episodeId: string;
-  switcher: React.ReactNode;
-}) {
-  const episode = useGetEpisode(episodeId);
-  const [collapsed, setCollapsed] = useState(false);
-  const lastScrollTopRef = useRef(0);
-  const scrollAccumRef = useRef(0);
-
-  function onTracksScroll(e: React.UIEvent<HTMLDivElement>) {
-    const el = e.currentTarget;
-    const top = el.scrollTop;
-    const delta = top - lastScrollTopRef.current;
-    lastScrollTopRef.current = top;
-
-    if (isProgrammaticScroll(el)) {
-      scrollAccumRef.current = 0;
-      return;
-    }
-
-    if (top <= 8) {
-      scrollAccumRef.current = 0;
-      setCollapsed(false);
-      return;
-    }
-
-    // accumulate travel in one direction; a direction flip starts over
-    if (Math.sign(delta) !== Math.sign(scrollAccumRef.current)) {
-      scrollAccumRef.current = 0;
-    }
-    scrollAccumRef.current += delta;
-
-    if (scrollAccumRef.current > 48) {
-      setCollapsed(true);
-    } else if (scrollAccumRef.current < -48) {
-      setCollapsed(false);
-    }
-  }
-
-  return (
-    <div className="relative flex h-full w-full flex-col items-center space-y-3 overflow-hidden pb-safe-top">
-      {collapsed ? (
-        <div className="flex w-full items-center space-x-3 px-4 pt-4">
-          <motion.img
-            layoutId="episode-sheet-details-artwork"
-            transition={detailsMorphTransition}
-            style={{ borderRadius: 6 }}
-            className="h-12 w-12 shrink-0 object-cover"
-            src={episode.artworkUrl}
-            alt={episode.name}
-          />
-          <motion.div
-            layoutId="episode-sheet-details-title"
-            transition={detailsMorphTransition}
-            className="min-w-0 flex-1 text-left"
-          >
-            <div className="truncate font-bold text-white">{episode.name}</div>
-            <div className="text-sm text-white/80">
-              {formatDate(episode.releasedAt)}
-            </div>
-          </motion.div>
-        </div>
-      ) : (
-        <div className="w-full flex-col space-y-3 px-4 pt-6">
-          <motion.img
-            layoutId="episode-sheet-details-artwork"
-            transition={detailsMorphTransition}
-            style={{ borderRadius: 8 }}
-            className="min-h-40 min-w-40 mx-auto w-full max-w-sm object-fill"
-            src={episode.artworkUrl}
-            alt={episode.name}
-          />
-          <motion.div
-            layoutId="episode-sheet-details-title"
-            transition={detailsMorphTransition}
-            className="flex w-full flex-col text-center"
-          >
-            <div className="font-bold text-white">{episode.name}</div>
-            <div className="text-sm text-white/80">
-              {formatDate(episode.releasedAt)}
-            </div>
-          </motion.div>
-        </div>
-      )}
-      <motion.div
-        layout="position"
-        transition={detailsMorphTransition}
-        className="w-full px-6"
-      >
-        <EpisodeSheetPlayer episodeId={episodeId} />
-      </motion.div>
-      <motion.div
-        layout="position"
-        transition={detailsMorphTransition}
-        className="w-full"
-      >
-        <EpisodeSheetActionButtons episodeId={episodeId} />
-      </motion.div>
-      <motion.div
-        layout="position"
-        transition={detailsMorphTransition}
-        className="w-full"
-      >
-        {switcher}
-      </motion.div>
-      <motion.div
-        layout="position"
-        transition={detailsMorphTransition}
-        className="relative mx-3 flex min-h-[10rem] flex-1 flex-col self-stretch rounded-lg"
-      >
-        <div className="absolute rounded-lg inset-0 bg-black/20"></div>
-        <div
-          onScroll={onTracksScroll}
-          className="relative min-h-0 overflow-y-auto"
+      <div className="grid w-full grid-cols-2 gap-x-2 px-4">
+        <a
+          href={episode.permalinkUrl}
+          className="inline-flex w-full flex-1 items-center justify-center space-x-1 rounded-md border-2 border-white bg-transparent px-2 py-1 text-center text-xs font-semibold text-white"
         >
-          <EpisodeTracksList episodeId={episodeId} />
+          <span
+            className={classNames("inline-block rounded-full p-1")}
+            title="Open in SoundCloud"
+          >
+            <IconSoundcloud className="h-4 w-4 fill-current" />
+          </span>
+          <span>Open in SoundCloud</span>
+        </a>
+        <EpisodeSheetFavoriteToggle episodeId={episodeId} />
+      </div>
+      {hasTracks && (
+        <div className="relative mx-3 flex h-1/2 min-h-[14rem] shrink-0 flex-col self-stretch rounded-lg">
+          <div className="absolute rounded-lg inset-0 bg-black/20"></div>
+          <div className="relative min-h-0 overflow-y-auto">
+            <EpisodeTracksList episodeId={episodeId} />
+          </div>
         </div>
-      </motion.div>
+      )}
       <br />
     </div>
   );
@@ -388,20 +141,6 @@ export function useEpisodeTracks(episodeId: string, enabled: boolean = true) {
     loaded: status === "success",
     hasTracks: status === "success" && data.length > 0,
   };
-}
-
-/**
- * The tracks list auto-scrolls to center the active track, and those
- * programmatic scrolls must be distinguishable from user scrolling so
- * layouts like the Morph variant only react to the user. The container
- * gets stamped with a timestamp covering the smooth-scroll duration.
- */
-function markProgrammaticScroll(container: HTMLElement) {
-  container.dataset.programmaticScrollUntil = String(Date.now() + 800);
-}
-
-function isProgrammaticScroll(container: HTMLElement) {
-  return Date.now() < Number(container.dataset.programmaticScrollUntil ?? 0);
 }
 
 function getScrollParent(el: HTMLElement): HTMLElement | null {
@@ -463,7 +202,6 @@ export function EpisodeTracksList({ episodeId }: { episodeId: string }) {
         elRect.top -
         containerRect.top -
         (container.clientHeight - elRect.height) / 2;
-      markProgrammaticScroll(container);
       container.scrollTo({
         top: container.scrollTop + delta,
         behavior,

--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -270,10 +270,13 @@ function EpisodeSheetStackedContent({
 }
 
 /**
- * "Morph" variant: same layout as "Half", but scrolling the tracks list
- * collapses the episode details (big artwork + title) into a compact
- * thumbnail row, and the tracks area grows into the freed space. The
- * player and action buttons stay put.
+ * "Morph" variant: same layout as "Half", but the user scrolling the
+ * tracks list collapses the episode details (big artwork + title) into
+ * a compact thumbnail row, and the tracks area grows into the freed
+ * space. The player and action buttons stay put. Driven by user scroll
+ * direction only: scrolling down collapses, scrolling up (or reaching
+ * the top) expands, and the list's own programmatic active-track
+ * centering never toggles it.
  */
 function EpisodeSheetMorphDetailsContent({
   episodeId,
@@ -284,11 +287,37 @@ function EpisodeSheetMorphDetailsContent({
 }) {
   const episode = useGetEpisode(episodeId);
   const [collapsed, setCollapsed] = useState(false);
+  const lastScrollTopRef = useRef(0);
+  const scrollAccumRef = useRef(0);
 
   function onTracksScroll(e: React.UIEvent<HTMLDivElement>) {
-    const top = e.currentTarget.scrollTop;
-    // hysteresis so the details don't flicker around the threshold
-    setCollapsed((c) => (c ? top > 24 : top > 64));
+    const el = e.currentTarget;
+    const top = el.scrollTop;
+    const delta = top - lastScrollTopRef.current;
+    lastScrollTopRef.current = top;
+
+    if (isProgrammaticScroll(el)) {
+      scrollAccumRef.current = 0;
+      return;
+    }
+
+    if (top <= 8) {
+      scrollAccumRef.current = 0;
+      setCollapsed(false);
+      return;
+    }
+
+    // accumulate travel in one direction; a direction flip starts over
+    if (Math.sign(delta) !== Math.sign(scrollAccumRef.current)) {
+      scrollAccumRef.current = 0;
+    }
+    scrollAccumRef.current += delta;
+
+    if (scrollAccumRef.current > 48) {
+      setCollapsed(true);
+    } else if (scrollAccumRef.current < -48) {
+      setCollapsed(false);
+    }
   }
 
   return (
@@ -351,6 +380,20 @@ export function useEpisodeTracks(episodeId: string, enabled: boolean = true) {
   };
 }
 
+/**
+ * The tracks list auto-scrolls to center the active track, and those
+ * programmatic scrolls must be distinguishable from user scrolling so
+ * layouts like the Morph variant only react to the user. The container
+ * gets stamped with a timestamp covering the smooth-scroll duration.
+ */
+function markProgrammaticScroll(container: HTMLElement) {
+  container.dataset.programmaticScrollUntil = String(Date.now() + 800);
+}
+
+function isProgrammaticScroll(container: HTMLElement) {
+  return Date.now() < Number(container.dataset.programmaticScrollUntil ?? 0);
+}
+
 function getScrollParent(el: HTMLElement): HTMLElement | null {
   let node = el.parentElement;
   while (node) {
@@ -410,6 +453,7 @@ export function EpisodeTracksList({ episodeId }: { episodeId: string }) {
         elRect.top -
         containerRect.top -
         (container.clientHeight - elRect.height) / 2;
+      markProgrammaticScroll(container);
       container.scrollTo({
         top: container.scrollTop + delta,
         behavior,

--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -115,7 +115,7 @@ function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
         <div className="relative mx-3 flex h-1/2 min-h-[14rem] shrink-0 flex-col self-stretch rounded-lg">
           <div className="absolute rounded-lg inset-0 bg-black/20"></div>
           <div className="relative min-h-0 overflow-y-auto">
-            <EpisodeTracksList episodeId={episodeId} />
+            <EpisodeTracksList key={episodeId} episodeId={episodeId} />
           </div>
         </div>
       )}
@@ -163,18 +163,8 @@ export function EpisodeTracksList({ episodeId }: { episodeId: string }) {
   const playerActions = usePlayerActions();
   const progressSecs = progress / 1000;
 
-  const { data, status } = trpc["episode.getTracks"].useQuery(
-    {
-      episodeId,
-    },
-    {
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-    },
-  );
-
-  const loaded = status === "success";
-  const loadedData = loaded ? (data ? data : []) : [];
+  const { data, loaded } = useEpisodeTracks(episodeId);
+  const loadedData = loaded ? (data ?? []) : [];
 
   const possibleTracks = loadedData.filter((t) =>
     t.timestamp ? progressSecs >= t.timestamp : false,
@@ -198,6 +188,11 @@ export function EpisodeTracksList({ episodeId }: { episodeId: string }) {
       if (!container) return;
       const containerRect = container.getBoundingClientRect();
       const elRect = el.getBoundingClientRect();
+      // Already fully visible: leave it be, so we don't fight the user's
+      // scroll position or yank a short list that fits without scrolling.
+      if (elRect.top >= containerRect.top && elRect.bottom <= containerRect.bottom) {
+        return;
+      }
       const delta =
         elRect.top -
         containerRect.top -
@@ -236,11 +231,11 @@ export function EpisodeTracksList({ episodeId }: { episodeId: string }) {
           {loadedData.length} Tracks
         </div>
         <div className="relative space-y">
-          {loadedData.map((t, i) => {
+          {loadedData.map((t) => {
             const isCurrent = currentTrack?.order === t.order;
             return (
               <button
-                key={`${t.order}-${i}`}
+                key={t.order}
                 ref={isCurrent ? currentTrackRef : undefined}
                 onClick={() => onTrackClick(t)}
                 className={cn("w-full relative hover:bg-white/10")}

--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "../PlayerStore";
 import { useGetEpisode } from "../useEpisodeHooks";
 import Sheet from "react-modal-sheet";
+import { motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import create from "zustand";
 import { trpc } from "@/utils/trpc";
@@ -131,48 +132,6 @@ function TracksVariantSwitcher({
   );
 }
 
-function EpisodeSheetCompactTitle({ episodeId }: { episodeId: string }) {
-  const episode = useGetEpisode(episodeId);
-  return (
-    <div className="flex w-full items-center space-x-3 px-4">
-      <img
-        className="h-12 w-12 shrink-0 rounded-md object-cover"
-        src={episode.artworkUrl}
-        alt={episode.name}
-      />
-      <div className="min-w-0 flex-1 text-left">
-        <div className="truncate font-bold text-white">{episode.name}</div>
-        <div className="text-sm text-white/80">
-          {formatDate(episode.releasedAt)}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/**
- * Collapses its content to zero height (animating grid-template-rows so
- * siblings in the flex column reflow smoothly as it opens/closes).
- */
-function CollapsibleSection({
-  collapsed,
-  children,
-}: {
-  collapsed: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "grid w-full transition-[grid-template-rows,opacity] duration-300 ease-out",
-        collapsed ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100",
-      )}
-    >
-      <div className="min-h-0 w-full overflow-hidden">{children}</div>
-    </div>
-  );
-}
-
 function EpisodeSheetActionButtons({ episodeId }: { episodeId: string }) {
   const episode = useGetEpisode(episodeId);
   return (
@@ -269,14 +228,22 @@ function EpisodeSheetStackedContent({
   );
 }
 
+const detailsMorphTransition = {
+  type: "spring",
+  bounce: 0.15,
+  duration: 0.45,
+} as const;
+
 /**
  * "Morph" variant: same layout as "Half", but the user scrolling the
- * tracks list collapses the episode details (big artwork + title) into
- * a compact thumbnail row, and the tracks area grows into the freed
- * space. The player and action buttons stay put. Driven by user scroll
- * direction only: scrolling down collapses, scrolling up (or reaching
- * the top) expands, and the list's own programmatic active-track
- * centering never toggles it.
+ * tracks list collapses the episode details into a compact thumbnail
+ * row, and the tracks area grows into the freed space. The artwork and
+ * title are shared elements (framer-motion layoutId) that travel
+ * between their expanded and compact positions, while the player,
+ * buttons, and tracks glide along via position layout animations.
+ * Driven by user scroll direction only: scrolling down collapses,
+ * scrolling up (or reaching the top) expands, and the list's own
+ * programmatic active-track centering never toggles it.
  */
 function EpisodeSheetMorphDetailsContent({
   episodeId,
@@ -322,32 +289,75 @@ function EpisodeSheetMorphDetailsContent({
 
   return (
     <div className="relative flex h-full w-full flex-col items-center space-y-3 overflow-hidden pb-safe-top">
-      <CollapsibleSection collapsed={collapsed}>
-        <div className="w-full flex-col space-y-3 px-4 pt-6">
-          <img
-            className="min-h-40 min-w-40 mx-auto w-full max-w-sm rounded-lg object-fill"
+      {collapsed ? (
+        <div className="flex w-full items-center space-x-3 px-4 pt-4">
+          <motion.img
+            layoutId="episode-sheet-details-artwork"
+            transition={detailsMorphTransition}
+            style={{ borderRadius: 6 }}
+            className="h-12 w-12 shrink-0 object-cover"
             src={episode.artworkUrl}
             alt={episode.name}
           />
-          <div className="flex w-full flex-col text-center">
+          <motion.div
+            layoutId="episode-sheet-details-title"
+            transition={detailsMorphTransition}
+            className="min-w-0 flex-1 text-left"
+          >
+            <div className="truncate font-bold text-white">{episode.name}</div>
+            <div className="text-sm text-white/80">
+              {formatDate(episode.releasedAt)}
+            </div>
+          </motion.div>
+        </div>
+      ) : (
+        <div className="w-full flex-col space-y-3 px-4 pt-6">
+          <motion.img
+            layoutId="episode-sheet-details-artwork"
+            transition={detailsMorphTransition}
+            style={{ borderRadius: 8 }}
+            className="min-h-40 min-w-40 mx-auto w-full max-w-sm object-fill"
+            src={episode.artworkUrl}
+            alt={episode.name}
+          />
+          <motion.div
+            layoutId="episode-sheet-details-title"
+            transition={detailsMorphTransition}
+            className="flex w-full flex-col text-center"
+          >
             <div className="font-bold text-white">{episode.name}</div>
             <div className="text-sm text-white/80">
               {formatDate(episode.releasedAt)}
             </div>
-          </div>
+          </motion.div>
         </div>
-      </CollapsibleSection>
-      <CollapsibleSection collapsed={!collapsed}>
-        <div className="pt-4">
-          <EpisodeSheetCompactTitle episodeId={episodeId} />
-        </div>
-      </CollapsibleSection>
-      <div className="w-full px-6">
+      )}
+      <motion.div
+        layout="position"
+        transition={detailsMorphTransition}
+        className="w-full px-6"
+      >
         <EpisodeSheetPlayer episodeId={episodeId} />
-      </div>
-      <EpisodeSheetActionButtons episodeId={episodeId} />
-      {switcher}
-      <div className="relative mx-3 flex min-h-[10rem] flex-1 flex-col self-stretch rounded-lg">
+      </motion.div>
+      <motion.div
+        layout="position"
+        transition={detailsMorphTransition}
+        className="w-full"
+      >
+        <EpisodeSheetActionButtons episodeId={episodeId} />
+      </motion.div>
+      <motion.div
+        layout="position"
+        transition={detailsMorphTransition}
+        className="w-full"
+      >
+        {switcher}
+      </motion.div>
+      <motion.div
+        layout="position"
+        transition={detailsMorphTransition}
+        className="relative mx-3 flex min-h-[10rem] flex-1 flex-col self-stretch rounded-lg"
+      >
         <div className="absolute rounded-lg inset-0 bg-black/20"></div>
         <div
           onScroll={onTracksScroll}
@@ -355,7 +365,7 @@ function EpisodeSheetMorphDetailsContent({
         >
           <EpisodeTracksList episodeId={episodeId} />
         </div>
-      </div>
+      </motion.div>
       <br />
     </div>
   );

--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -2,10 +2,6 @@ import {
   IconSoundcloud,
   HeartFilled,
   HeartOutline,
-  IconPlay,
-  IconPause,
-  IconBackThirty,
-  IconSkipThirty,
 } from "@/client/components/Icons";
 import { formatDate, formatTimeSecs } from "@/client/helpers";
 import classNames from "classnames";
@@ -78,12 +74,10 @@ export function EpisodeModalSheet({
   );
 }
 
-type TracksAreaVariant = "half" | "tall" | "full" | "morph";
+type TracksAreaVariant = "half" | "morph";
 
 const tracksAreaVariants: { id: TracksAreaVariant; label: string }[] = [
   { id: "half", label: "Half" },
-  { id: "tall", label: "Tall" },
-  { id: "full", label: "Full" },
   { id: "morph", label: "Morph" },
 ];
 
@@ -156,60 +150,25 @@ function EpisodeSheetCompactTitle({ episodeId }: { episodeId: string }) {
   );
 }
 
-function CompactSheetPlayerControls() {
-  const playing = usePlayerPlaying();
-  const loadingStatus = usePlayerLoadingStatus();
-  const playerActions = usePlayerActions();
-  const loading = loadingStatus === "loading";
-
+/**
+ * Collapses its content to zero height (animating grid-template-rows so
+ * siblings in the flex column reflow smoothly as it opens/closes).
+ */
+function CollapsibleSection({
+  collapsed,
+  children,
+}: {
+  collapsed: boolean;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="flex shrink-0 items-center space-x-1">
-      <button
-        title="Rewind 30 seconds"
-        onClick={() => playerActions.rewind(30)}
-        className="rounded-full p-1 text-white hover:text-white/80 focus:outline-none"
-      >
-        <IconBackThirty className="h-7 w-7 fill-current" />
-      </button>
-      <button
-        disabled={loading}
-        onClick={() => (playing ? playerActions.pause() : playerActions.resume())}
-        className="rounded-full bg-white p-2 leading-none text-accent shadow-md focus:outline-none"
-      >
-        {loading ? (
-          <svg
-            viewBox="0 0 20 20"
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-6 w-6 animate-ping p-1"
-          >
-            <circle cx="10" cy="10" r="9" fill="currentColor" />
-          </svg>
-        ) : playing ? (
-          <IconPause className="h-6 w-6 fill-current" />
-        ) : (
-          <IconPlay className="h-6 w-6 fill-current" />
-        )}
-      </button>
-      <button
-        title="Forward 30 seconds"
-        onClick={() => playerActions.forward(30)}
-        className="rounded-full p-1 text-white hover:text-white/80 focus:outline-none"
-      >
-        <IconSkipThirty className="h-7 w-7 fill-current" />
-      </button>
-    </div>
-  );
-}
-
-function PlayerProgressHairline() {
-  const progress = usePlayerProgress();
-  const episodeDuration = usePlayerEpisodeDuration();
-  const pct =
-    episodeDuration > 0 ? Math.min(100, (progress / episodeDuration) * 100) : 0;
-
-  return (
-    <div className="h-0.5 w-full bg-white/20">
-      <div className="h-full bg-white/90" style={{ width: `${pct}%` }} />
+    <div
+      className={cn(
+        "grid w-full transition-[grid-template-rows,opacity] duration-300 ease-out",
+        collapsed ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100",
+      )}
+    >
+      <div className="min-h-0 w-full overflow-hidden">{children}</div>
     </div>
   );
 }
@@ -239,60 +198,37 @@ function EpisodeSheetContent({ episodeId }: { episodeId: string }) {
   const { hasTracks } = useEpisodeTracks(episodeId);
   const [tracksVariant, setTracksVariant] = useTracksAreaVariant();
 
-  if (hasTracks && tracksVariant === "full") {
-    return (
-      <EpisodeSheetFullContent
-        episodeId={episodeId}
-        switcher={
-          <TracksVariantSwitcher
-            variant={tracksVariant}
-            onChange={setTracksVariant}
-          />
-        }
-      />
-    );
-  }
+  const switcher = (
+    <TracksVariantSwitcher
+      variant={tracksVariant}
+      onChange={setTracksVariant}
+    />
+  );
 
   if (hasTracks && tracksVariant === "morph") {
     return (
-      <EpisodeSheetMorphContent
+      <EpisodeSheetMorphDetailsContent
         episodeId={episodeId}
-        switcher={
-          <TracksVariantSwitcher
-            variant={tracksVariant}
-            onChange={setTracksVariant}
-          />
-        }
+        switcher={switcher}
       />
     );
   }
 
   return (
-    <EpisodeSheetStackedContent
-      episodeId={episodeId}
-      variant={tracksVariant}
-      switcher={
-        <TracksVariantSwitcher
-          variant={tracksVariant}
-          onChange={setTracksVariant}
-        />
-      }
-    />
+    <EpisodeSheetStackedContent episodeId={episodeId} switcher={switcher} />
   );
 }
 
 /**
- * "Half" / "Tall" variants (also the fallback when the episode has no
- * tracks): full artwork, player, and action buttons stacked, with the
- * tracks area taking a fixed share of the sheet height.
+ * "Half" variant (also the fallback when the episode has no tracks):
+ * full artwork, player, and action buttons stacked, with the tracks
+ * area taking half the sheet height.
  */
 function EpisodeSheetStackedContent({
   episodeId,
-  variant,
   switcher,
 }: {
   episodeId: string;
-  variant: TracksAreaVariant;
   switcher: React.ReactNode;
 }) {
   const episode = useGetEpisode(episodeId);
@@ -320,17 +256,10 @@ function EpisodeSheetStackedContent({
       {hasTracks && (
         <>
           {switcher}
-          <div
-            className={cn(
-              "relative mx-3 flex shrink-0 flex-col self-stretch rounded-lg",
-              variant === "tall"
-                ? "h-[62%] min-h-[16rem]"
-                : "h-1/2 min-h-[14rem]",
-            )}
-          >
+          <div className="relative mx-3 flex h-1/2 min-h-[14rem] shrink-0 flex-col self-stretch rounded-lg">
             <div className="absolute rounded-lg inset-0 bg-black/20"></div>
             <div className="relative min-h-0 overflow-y-auto">
-              <EpisodeTracksList key={variant} episodeId={episodeId} />
+              <EpisodeTracksList episodeId={episodeId} />
             </div>
           </div>
         </>
@@ -341,41 +270,12 @@ function EpisodeSheetStackedContent({
 }
 
 /**
- * "Full" variant: the tracks take all the space between a compact title
- * row at the top and the untouched full player controls docked at the
- * bottom.
+ * "Morph" variant: same layout as "Half", but scrolling the tracks list
+ * collapses the episode details (big artwork + title) into a compact
+ * thumbnail row, and the tracks area grows into the freed space. The
+ * player and action buttons stay put.
  */
-function EpisodeSheetFullContent({
-  episodeId,
-  switcher,
-}: {
-  episodeId: string;
-  switcher: React.ReactNode;
-}) {
-  return (
-    <div className="relative flex h-full w-full flex-col space-y-3 overflow-hidden pb-safe-top pt-4">
-      <EpisodeSheetCompactTitle episodeId={episodeId} />
-      {switcher}
-      <div className="relative mx-3 flex min-h-0 flex-1 flex-col rounded-lg">
-        <div className="absolute rounded-lg inset-0 bg-black/20"></div>
-        <div className="relative min-h-0 overflow-y-auto">
-          <EpisodeTracksList episodeId={episodeId} />
-        </div>
-      </div>
-      <div className="w-full px-6">
-        <EpisodeSheetPlayer episodeId={episodeId} />
-      </div>
-    </div>
-  );
-}
-
-/**
- * "Morph" variant: the sheet scrolls as one column, and once the user
- * scrolls past the artwork a compact header (thumbnail, title, inline
- * player controls, progress hairline) slides in over the top, leaving
- * the rest of the sheet to the tracks.
- */
-function EpisodeSheetMorphContent({
+function EpisodeSheetMorphDetailsContent({
   episodeId,
   switcher,
 }: {
@@ -385,50 +285,16 @@ function EpisodeSheetMorphContent({
   const episode = useGetEpisode(episodeId);
   const [collapsed, setCollapsed] = useState(false);
 
-  function onSheetScroll(e: React.UIEvent<HTMLDivElement>) {
+  function onTracksScroll(e: React.UIEvent<HTMLDivElement>) {
     const top = e.currentTarget.scrollTop;
-    // hysteresis so the header doesn't flicker around the threshold
-    setCollapsed((c) => (c ? top > 150 : top > 190));
+    // hysteresis so the details don't flicker around the threshold
+    setCollapsed((c) => (c ? top > 24 : top > 64));
   }
 
   return (
-    <div className="relative h-full w-full overflow-hidden">
-      <div
-        className={cn(
-          "absolute inset-x-0 top-0 z-10 bg-accent transition-all duration-300",
-          collapsed
-            ? "translate-y-0 opacity-100"
-            : "pointer-events-none -translate-y-3 opacity-0",
-        )}
-      >
-        <div className="flex w-full items-center space-x-3 px-4 py-2">
-          <img
-            className="h-12 w-12 shrink-0 rounded-md object-cover"
-            src={episode.artworkUrl}
-            alt={episode.name}
-          />
-          <div className="min-w-0 flex-1 text-left">
-            <div className="truncate text-sm font-bold text-white">
-              {episode.name}
-            </div>
-            <div className="text-xs text-white/80">
-              {formatDate(episode.releasedAt)}
-            </div>
-          </div>
-          <CompactSheetPlayerControls />
-        </div>
-        <PlayerProgressHairline />
-      </div>
-      <div
-        onScroll={onSheetScroll}
-        className="flex h-full w-full flex-col items-center space-y-3 overflow-y-auto pb-safe-top"
-      >
-        <div
-          className={cn(
-            "w-full flex-col space-y-3 px-4 pt-6 transition-all duration-300",
-            collapsed && "scale-95 opacity-0",
-          )}
-        >
+    <div className="relative flex h-full w-full flex-col items-center space-y-3 overflow-hidden pb-safe-top">
+      <CollapsibleSection collapsed={collapsed}>
+        <div className="w-full flex-col space-y-3 px-4 pt-6">
           <img
             className="min-h-40 min-w-40 mx-auto w-full max-w-sm rounded-lg object-fill"
             src={episode.artworkUrl}
@@ -441,24 +307,27 @@ function EpisodeSheetMorphContent({
             </div>
           </div>
         </div>
-        <div
-          className={cn(
-            "w-full px-6 transition-opacity duration-300",
-            collapsed && "opacity-0",
-          )}
-        >
-          <EpisodeSheetPlayer episodeId={episodeId} />
+      </CollapsibleSection>
+      <CollapsibleSection collapsed={!collapsed}>
+        <div className="pt-4">
+          <EpisodeSheetCompactTitle episodeId={episodeId} />
         </div>
-        <EpisodeSheetActionButtons episodeId={episodeId} />
-        {switcher}
-        <div className="relative mx-3 self-stretch rounded-lg">
-          <div className="absolute rounded-lg inset-0 bg-black/20"></div>
-          <div className="relative">
-            <EpisodeTracksList episodeId={episodeId} />
-          </div>
-        </div>
-        <br />
+      </CollapsibleSection>
+      <div className="w-full px-6">
+        <EpisodeSheetPlayer episodeId={episodeId} />
       </div>
+      <EpisodeSheetActionButtons episodeId={episodeId} />
+      {switcher}
+      <div className="relative mx-3 flex min-h-[10rem] flex-1 flex-col self-stretch rounded-lg">
+        <div className="absolute rounded-lg inset-0 bg-black/20"></div>
+        <div
+          onScroll={onTracksScroll}
+          className="relative min-h-0 overflow-y-auto"
+        >
+          <EpisodeTracksList episodeId={episodeId} />
+        </div>
+      </div>
+      <br />
     </div>
   );
 }


### PR DESCRIPTION
When an episode with a tracklist is playing, the currently active track auto-scrolls to the vertical center of its nearest scrollable container — instantly on first open and smoothly as playback moves between tracks. It only scrolls when the track isn't already fully visible, so it doesn't fight the user's scroll position or yank a short list around. The first-open centering resets per episode. Works for both the desktop inline tracks panel and the mobile episode sheet.

On mobile, the tracks list in the episode sheet is constrained to the space left over by the artwork, player controls, and action buttons, scrolling internally instead of growing the whole sheet.