### PR TITLE
Add Shift+arrow track-skip / incrementing fast-forward shortcut

### DIFF
--- a/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
+++ b/src/client/EpisodesScreen/EpisodeModalSheet/index.tsx
@@ -16,6 +16,7 @@ import {
   usePlayerLoadingStatus,
   usePlayerActions,
   usePlayerCuePosition,
+  usePlayerSkipInterval,
 } from "../PlayerStore";
 import { useGetEpisode } from "../useEpisodeHooks";
 import Sheet from "react-modal-sheet";
@@ -340,6 +341,7 @@ export function EpisodeSheetPlayer({ episodeId }: EpisodeSheetPlayerProps) {
   const progress = usePlayerProgress();
   const episodeDuration = usePlayerEpisodeDuration();
   const loadingStatus = usePlayerLoadingStatus();
+  const skipInterval = usePlayerSkipInterval();
   const currentEpisode = useGetEpisode(episodeId);
 
   const playerActions = usePlayerActions();
@@ -361,6 +363,7 @@ export function EpisodeSheetPlayer({ episodeId }: EpisodeSheetPlayerProps) {
       onRewind={playerActions.rewind}
       episodeDuration={episodeDuration}
       loading={loadingStatus === "loading"}
+      skipInterval={skipInterval}
     />
   );
 }

--- a/src/client/EpisodesScreen/Player/MiniPlayerControls.tsx
+++ b/src/client/EpisodesScreen/Player/MiniPlayerControls.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useLayoutEffect, useState } from "react";
 import { formatDate } from "../../helpers";
-import { IconPause, IconPlay, IconSkipThirty } from "../../components/Icons";
+import { IconPause, IconPlay, IconSkipSeconds } from "../../components/Icons";
 import cx from "classnames";
 import { motion } from "framer-motion";
 import { PlayerControlsProps } from "./PlayerControls";
@@ -86,6 +86,7 @@ export function MiniPlayerControls({
   onForward,
   onRewind,
   loading,
+  skipInterval,
   onClick,
 }: MiniPlayerControlsPromps) {
   return (
@@ -124,8 +125,8 @@ export function MiniPlayerControls({
         <div className="flex items-center justify-center space-x-4">
           <motion.button
             whileTap={{ scale: 0.9 }}
-            title="Forward 30 seconds"
-            onClick={() => onForward(30)}
+            title={`Forward ${skipInterval} seconds`}
+            onClick={() => onForward(skipInterval)}
             className={cx(
               "rounded-fullp-1 text-gray-700",
               "transition-all duration-200 ease-in-out",
@@ -133,7 +134,7 @@ export function MiniPlayerControls({
               "focus:bg-gray-200 focus:outline-none"
             )}
           >
-            <IconSkipThirty className="h-8 w-8 fill-current" />
+            <IconSkipSeconds seconds={skipInterval} className="h-8 w-8 fill-current" />
           </motion.button>
           <motion.button
             whileTap={{ scale: 0.9 }}

--- a/src/client/EpisodesScreen/Player/MobilePlayerControls.tsx
+++ b/src/client/EpisodesScreen/Player/MobilePlayerControls.tsx
@@ -3,8 +3,8 @@ import { formatTime } from "../../helpers";
 import {
   IconPause,
   IconPlay,
-  IconBackThirty,
-  IconSkipThirty,
+  IconBackSeconds,
+  IconSkipSeconds,
 } from "../../components/Icons";
 import cx from "classnames";
 import { Slider } from "@/client/components/Slider";
@@ -27,6 +27,7 @@ export function MobilePlayerControls({
   onForward,
   onRewind,
   loading,
+  skipInterval,
 }: PlayerControlsProps) {
   const [seeking, setSeeking] = useState(false);
   const [seekPosition, setSeekPosition] = useState(progress);
@@ -96,8 +97,8 @@ export function MobilePlayerControls({
       <div className="flex items-center justify-center space-x-6">
         <motion.button
           whileTap={{ scale: 0.9 }}
-          title="Rewind 30 seconds"
-          onClick={() => onRewind(30)}
+          title={`Rewind ${skipInterval} seconds`}
+          onClick={() => onRewind(skipInterval)}
           className={cx(
             "rounded-full bg-transparent p-2 text-white",
             "transition-all duration-200 ease-in-out",
@@ -105,7 +106,7 @@ export function MobilePlayerControls({
             "focus:bg-white/80 focus:outline-none"
           )}
         >
-          <IconBackThirty className="h-12 w-12 fill-current" />
+          <IconBackSeconds seconds={skipInterval} className="h-12 w-12 fill-current" />
         </motion.button>
         <motion.button
           whileTap={{ scale: 0.9 }}
@@ -151,8 +152,8 @@ export function MobilePlayerControls({
 
         <motion.button
           whileTap={{ scale: 0.9 }}
-          title="Forward 30 seconds"
-          onClick={() => onForward(30)}
+          title={`Forward ${skipInterval} seconds`}
+          onClick={() => onForward(skipInterval)}
           className={cx(
             "rounded-full bg-transparent p-2 text-white",
             "transition-all duration-200 ease-in-out",
@@ -160,7 +161,7 @@ export function MobilePlayerControls({
             "focus:bg-white/80 focus:outline-none"
           )}
         >
-          <IconSkipThirty className="h-12 w-12 fill-current" />
+          <IconSkipSeconds seconds={skipInterval} className="h-12 w-12 fill-current" />
         </motion.button>
       </div>
     </div>

--- a/src/client/EpisodesScreen/Player/PlayerControls.tsx
+++ b/src/client/EpisodesScreen/Player/PlayerControls.tsx
@@ -3,8 +3,8 @@ import { formatDate, formatTime } from "../../helpers";
 import {
   IconPause,
   IconPlay,
-  IconBackThirty,
-  IconSkipThirty,
+  IconBackSeconds,
+  IconSkipSeconds,
   IconSoundcloud,
   IconSpeaker,
 } from "../../components/Icons";
@@ -30,6 +30,7 @@ export type PlayerControlsProps = {
   onRewind: (secs: number) => void;
   episodeDuration: number;
   loading: boolean;
+  skipInterval: number;
 };
 export function PlayerControls({
   episode,
@@ -47,6 +48,7 @@ export function PlayerControls({
   onForward,
   onRewind,
   loading,
+  skipInterval,
 }: PlayerControlsProps) {
   const [seeking, setSeeking] = useState(false);
   const [seekPosition, setSeekPosition] = useState(progress);
@@ -109,8 +111,8 @@ export function PlayerControls({
         <div className="flex items-center justify-center space-x-4">
           <motion.button
             whileTap={{ scale: 0.9 }}
-            title="Rewind 30 seconds"
-            onClick={() => onRewind(30)}
+            title={`Rewind ${skipInterval} seconds`}
+            onClick={() => onRewind(skipInterval)}
             className={cx(
               "rounded-full bg-transparent p-2 text-gray-700",
               "transition-all duration-200 ease-in-out",
@@ -118,7 +120,7 @@ export function PlayerControls({
               "focus:bg-gray-200 focus:outline-none",
             )}
           >
-            <IconBackThirty className="h-8 w-8 fill-current" />
+            <IconBackSeconds seconds={skipInterval} className="h-8 w-8 fill-current" />
           </motion.button>
           <motion.button
             whileTap={{ scale: 0.9 }}
@@ -164,8 +166,8 @@ export function PlayerControls({
 
           <motion.button
             whileTap={{ scale: 0.9 }}
-            title="Forward 30 seconds"
-            onClick={() => onForward(30)}
+            title={`Forward ${skipInterval} seconds`}
+            onClick={() => onForward(skipInterval)}
             className={cx(
               "rounded-full bg-transparent p-2 text-gray-700",
               "transition-all duration-200 ease-in-out",
@@ -173,7 +175,7 @@ export function PlayerControls({
               "focus:bg-gray-200 focus:outline-none",
             )}
           >
-            <IconSkipThirty className="h-8 w-8 fill-current" />
+            <IconSkipSeconds seconds={skipInterval} className="h-8 w-8 fill-current" />
           </motion.button>
         </div>
         <div className="w-full max-w-3xl">

--- a/src/client/EpisodesScreen/Player/index.tsx
+++ b/src/client/EpisodesScreen/Player/index.tsx
@@ -8,6 +8,7 @@ import {
   usePlayerCuePosition,
   usePlayerEpisodeDuration,
   usePlayerLoadingStatus,
+  usePlayerSkipInterval,
 } from "../PlayerStore";
 import Head from "next/head";
 import { useGetEpisode } from "../useEpisodeHooks";
@@ -31,6 +32,7 @@ export default function Player({ currentEpisodeId }: PlayerProps) {
   const cuePosition = usePlayerCuePosition();
   const episodeDuration = usePlayerEpisodeDuration();
   const loadingStatus = usePlayerLoadingStatus();
+  const skipInterval = usePlayerSkipInterval();
 
   const playerActions = usePlayerActions();
   const episodeModalSheetActions = useEpisodeModalSheetActions();
@@ -98,6 +100,7 @@ export default function Player({ currentEpisodeId }: PlayerProps) {
             onRewind={playerActions.rewind}
             episodeDuration={episodeDuration}
             loading={loadingStatus === "loading"}
+            skipInterval={skipInterval}
           />
         )}
       </div>
@@ -119,6 +122,7 @@ export default function Player({ currentEpisodeId }: PlayerProps) {
           episodeDuration={episodeDuration}
           onClick={onMiniPlayerClick}
           loading={loadingStatus === "loading"}
+          skipInterval={skipInterval}
         />
       )}
     </>

--- a/src/client/EpisodesScreen/PlayerStore.tsx
+++ b/src/client/EpisodesScreen/PlayerStore.tsx
@@ -3,6 +3,21 @@ import { clamp } from "../helpers";
 
 type PlayerLoadingStatus = "loading" | "loaded" | "error";
 
+/**
+ * The skip amount (in seconds) used by the forward/back buttons and arrow-key
+ * shortcuts. Shift+arrow on an episode without tracks steps through these,
+ * "incrementing" the jump each press, and the current value is what the 30s
+ * player buttons display.
+ */
+export const SKIP_INTERVALS = [30, 60, 90, 120] as const;
+export const DEFAULT_SKIP_INTERVAL = SKIP_INTERVALS[0];
+
+function nextSkipInterval(current: number): number {
+  const idx = SKIP_INTERVALS.indexOf(current as (typeof SKIP_INTERVALS)[number]);
+  const nextIdx = (idx + 1) % SKIP_INTERVALS.length;
+  return SKIP_INTERVALS[nextIdx];
+}
+
 export type StreamUrls = {
   http_mp3_128_url: string;
   hls_mp3_128_url: string;
@@ -18,6 +33,7 @@ export type PlayerStore = {
   episodeDuration: number;
   cuePosition: number;
   lastVol: number;
+  skipInterval: number;
   loadingStatus: PlayerLoadingStatus;
   currentEpisodeStreamUrls: StreamUrls | null;
   /**
@@ -39,6 +55,8 @@ export type PlayerStore = {
     setCuePosition: (cuePos: number) => void;
     forward: (secs: number) => void;
     rewind: (secs: number) => void;
+    skipForwardIncrementing: () => void;
+    skipBackwardIncrementing: () => void;
     setEpisodeDuration: (duration: number) => void;
     loadEpisode: (episodeId: string, seekMillis?: number) => void;
     applyInitialSeek: () => void;
@@ -55,6 +73,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   progress: 0,
   episodeDuration: 0,
   cuePosition: 0,
+  skipInterval: DEFAULT_SKIP_INTERVAL,
   loadingStatus: "loading",
   currentEpisodeStreamUrls: null,
   initialSeekMillis: null,
@@ -158,6 +177,16 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
         cuePosition: get().progress - secs * 1000,
       });
     },
+    skipForwardIncrementing() {
+      const next = nextSkipInterval(get().skipInterval);
+      set({ skipInterval: next });
+      get().actions.forward(next);
+    },
+    skipBackwardIncrementing() {
+      const next = nextSkipInterval(get().skipInterval);
+      set({ skipInterval: next });
+      get().actions.rewind(next);
+    },
     setVolume(vol: number) {
       set({
         volume: clamp(vol, 0, 100),
@@ -201,6 +230,9 @@ export const usePlayerLoadingStatus = () =>
   usePlayerStore((s) => s.loadingStatus);
 export const usePlayerEpisodeDuration = () =>
   usePlayerStore((s) => s.episodeDuration);
+
+export const usePlayerSkipInterval = () =>
+  usePlayerStore((s) => s.skipInterval);
 
 export const usePlayerCurrentEpisodeId = () =>
   usePlayerStore((s) => s.currentEpisodeId);

--- a/src/client/components/Icons.tsx
+++ b/src/client/components/Icons.tsx
@@ -188,6 +188,52 @@ export function IconBackThirty(props: any) {
   );
 }
 
+// The circular-arrow shape shared with IconSkipThirty/IconBackThirty, but with
+// the baked-in "30" glyphs removed so we can render the current skip interval
+// as live text instead.
+const SKIP_RING =
+  "M10.54.43v2.93h-.26A10.09 10.09 0 00.43 13.42c0 5.56 4.53 10.07 10.1 10.07 5.59 0 10.11-4.5 10.11-10.07h-2.52a7.57 7.57 0 01-15.16 0 7.56 7.56 0 017.32-7.55h.26v3.3l4.8-4.3-4.8-4.44z";
+const BACK_RING =
+  "M10.55.43v2.93h.26c5.46.13 9.85 4.58 9.85 10.06 0 5.56-4.53 10.07-10.1 10.07C4.96 23.5.44 19 .44 13.42h2.52a7.57 7.57 0 0015.16 0 7.56 7.56 0 00-7.32-7.55h-.26v3.3l-4.8-4.3 4.8-4.44z";
+
+function SkipSecondsIcon({
+  seconds,
+  ring,
+  ...props
+}: { seconds: number; ring: string } & React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 24" {...props}>
+      <path fillRule="evenodd" d={ring} clipRule="evenodd" />
+      <text
+        x="10.5"
+        y="16.5"
+        textAnchor="middle"
+        fontSize={seconds >= 100 ? 6.5 : 8}
+        fontWeight={700}
+        fill="currentColor"
+        stroke="none"
+        style={{ fontFamily: "inherit" }}
+      >
+        {seconds}
+      </text>
+    </svg>
+  );
+}
+
+export function IconSkipSeconds({
+  seconds,
+  ...props
+}: { seconds: number } & React.SVGProps<SVGSVGElement>) {
+  return <SkipSecondsIcon seconds={seconds} ring={SKIP_RING} {...props} />;
+}
+
+export function IconBackSeconds({
+  seconds,
+  ...props
+}: { seconds: number } & React.SVGProps<SVGSVGElement>) {
+  return <SkipSecondsIcon seconds={seconds} ring={BACK_RING} {...props} />;
+}
+
 export function IconSearch(props: any) {
   return (
     <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" {...props}>

--- a/src/client/useKeyboardHandlers.tsx
+++ b/src/client/useKeyboardHandlers.tsx
@@ -2,6 +2,9 @@ import {
   usePlayerActions,
   usePlayerPlaying,
   usePlayerEpisodeDuration,
+  usePlayerCurrentEpisodeId,
+  usePlayerProgress,
+  usePlayerSkipInterval,
 } from "./EpisodesScreen/PlayerStore";
 import { useEffect, useMemo } from "react";
 import {
@@ -12,6 +15,21 @@ import {
   EVENT,
 } from "./helpers";
 import { useNavbarStore } from "./EpisodesScreen/Navbar";
+import { useEpisodeTracks } from "./EpisodesScreen/EpisodeModalSheet";
+import { EpisodeTrackProjection } from "@/server/router";
+
+// Tracks with a known timestamp, sorted so we can walk forward/back through
+// them regardless of the order they were stored in.
+function timedTracksSorted(
+  tracks: EpisodeTrackProjection[] | undefined,
+): (EpisodeTrackProjection & { timestamp: number })[] {
+  return (tracks ?? [])
+    .filter(
+      (t): t is EpisodeTrackProjection & { timestamp: number } =>
+        typeof t.timestamp === "number",
+    )
+    .sort((a, b) => a.timestamp - b.timestamp);
+}
 
 export interface KeyboardAction {
   perform: Function;
@@ -27,11 +45,59 @@ export function useShortcutHandlers() {
   const playerActions = usePlayerActions();
   const playing = usePlayerPlaying();
   const episodeDuration = usePlayerEpisodeDuration();
+  const progress = usePlayerProgress();
+  const skipInterval = usePlayerSkipInterval();
+  const currentEpisodeId = usePlayerCurrentEpisodeId();
   const openSearch = useNavbarStore((state) => state.openSearch);
+
+  const { data: tracks } = useEpisodeTracks(
+    currentEpisodeId ?? "",
+    Boolean(currentEpisodeId),
+  );
 
   const togglePlay = useMemo(() => {
     return playing ? playerActions.pause : playerActions.resume;
   }, [playing, playerActions]);
+
+  // Shift+forward: jump to the next track when the episode is tracklisted,
+  // otherwise fast-forward by an incrementing amount of time.
+  function skipForward() {
+    const progressSecs = progress / 1000;
+    const timed = timedTracksSorted(tracks);
+    const nextTrack = timed.find((t) => t.timestamp > progressSecs + 0.5);
+    if (nextTrack) {
+      playerActions.setCuePosition(nextTrack.timestamp * 1000);
+    } else {
+      playerActions.skipForwardIncrementing();
+    }
+  }
+
+  // Shift+back: jump to the previous track (or restart the current one when
+  // we're a few seconds into it), otherwise rewind by an incrementing amount.
+  function skipBackward() {
+    const progressSecs = progress / 1000;
+    const timed = timedTracksSorted(tracks);
+
+    let currentIdx = -1;
+    for (let i = 0; i < timed.length; i++) {
+      if (timed[i].timestamp <= progressSecs) {
+        currentIdx = i;
+      }
+    }
+
+    if (currentIdx === -1) {
+      playerActions.skipBackwardIncrementing();
+      return;
+    }
+
+    const RESTART_THRESHOLD_SECS = 3;
+    const intoCurrent = progressSecs - timed[currentIdx].timestamp;
+    const target =
+      intoCurrent > RESTART_THRESHOLD_SECS
+        ? timed[currentIdx]
+        : (timed[currentIdx - 1] ?? timed[0]);
+    playerActions.setCuePosition(target.timestamp * 1000);
+  }
 
   const keyboardActions: KeyboarActionsMap = {
     VOLUME_UP: {
@@ -58,17 +124,32 @@ export function useShortcutHandlers() {
       },
       perform: togglePlay,
     },
-    FORWARD_THIRTY: {
+    FORWARD_SKIP: {
       keyTest: (event: globalThis.KeyboardEvent) => {
-        return event.key === KEYS.ARROW_RIGHT;
+        return event.key === KEYS.ARROW_RIGHT && !event.shiftKey;
       },
-      perform: () => playerActions.forward(30),
+      perform: () => playerActions.forward(skipInterval),
     },
-    REWIND_THIRTY: {
+    REWIND_SKIP: {
       keyTest: (event: globalThis.KeyboardEvent) => {
-        return event.key === KEYS.ARROW_LEFT;
+        return event.key === KEYS.ARROW_LEFT && !event.shiftKey;
       },
-      perform: () => playerActions.rewind(30),
+      perform: () => playerActions.rewind(skipInterval),
+    },
+    SHIFT_FORWARD: {
+      // Higher priority so it wins over any plain ArrowRight handler.
+      keyPriority: 1,
+      keyTest: (event: globalThis.KeyboardEvent) => {
+        return event.key === KEYS.ARROW_RIGHT && event.shiftKey;
+      },
+      perform: skipForward,
+    },
+    SHIFT_REWIND: {
+      keyPriority: 1,
+      keyTest: (event: globalThis.KeyboardEvent) => {
+        return event.key === KEYS.ARROW_LEFT && event.shiftKey;
+      },
+      perform: skipBackward,
     },
     OPEN_SEARCH: {
       keyTest: (event: globalThis.KeyboardEvent) => {


### PR DESCRIPTION
Shift+Right and Shift+Left now skip to the next/previous track when the
current episode has a tracklist, and otherwise fast-forward/rewind by an
incrementing amount of time (30s → 60s → 90s → 120s, cycling).

The active skip interval is shared app-wide: the plain arrow keys and the
forward/back player buttons use it, and it is rendered live inside the
circular "30s" buttons via new parametric IconSkipSeconds/IconBackSeconds
icons (same arrow shape as before, digits replaced by the current value).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GTFiSZv1Hwq4fFroZiooPw