### PR TITLE
Publish a versioned iOS release per main build

### DIFF
--- a/.github/workflows/ios-sideload.yml
+++ b/.github/workflows/ios-sideload.yml
@@ -89,16 +89,21 @@ jobs:
               await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body });
             }
 
-      - name: Publish rolling release
+      # Every main build gets its own versioned release (run_number is a
+      # simple monotonic build number), with GitHub's auto-generated notes
+      # listing the changes since the previous release. The newest build is
+      # always reachable at .../releases/latest.
+      - name: Publish release
         if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: sideload-latest
-          name: Soulector iOS (latest sideload build)
+          tag_name: ios-build-${{ github.run_number }}
+          name: Soulector iOS build ${{ github.run_number }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
           body: |
-            Unsigned IPA for sideloading with SideStore.
-
-            Built from `${{ github.sha }}` on `${{ github.ref_name }}`.
+            Unsigned IPA for sideloading with SideStore, built from
+            `${{ github.sha }}` on `${{ github.ref_name }}`.
 
             **Install on iPhone:** download `Soulector.ipa` below in Safari,
             then open SideStore → My Apps → + → pick the downloaded file.


### PR DESCRIPTION
Each `main` build of the iOS app now publishes its own release instead of force-updating the single rolling `sideload-latest` tag:

- Tagged `ios-build-<run_number>` — the workflow run number acts as a simple monotonic build number, and the release name matches ("Soulector iOS build N").
- `generate_release_notes: true` appends GitHub's auto-generated notes, listing the PRs/commits landed since the previous release — the "what changed" for each build.
- The install instructions stay in the body, and the newest build remains reachable at a stable URL via `releases/latest` (GitHub moves the Latest pointer automatically).

PR builds are unchanged: IPA artifact + sticky comment, no release.

Note: the old `sideload-latest` release stays as-is and simply stops updating; it can be deleted whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fYivZEsJYdaAV9EHX5MFh

---
_Generated by [Claude Code](https://claude.ai/code/session_012fYivZEsJYdaAV9EHX5MFh)_